### PR TITLE
Update to C# 14 and .NET 10 CI/CD alignment

### DIFF
--- a/src/CashCtrlApiNet.Abstractions/CashCtrlApiNet.Abstractions.csproj
+++ b/src/CashCtrlApiNet.Abstractions/CashCtrlApiNet.Abstractions.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
-        <LangVersion>13</LangVersion>
+        <LangVersion>14</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>CashCtrlApiNet.Abstractions</RootNamespace>

--- a/src/CashCtrlApiNet.AspNetCore/CashCtrlApiNet.AspNetCore.csproj
+++ b/src/CashCtrlApiNet.AspNetCore/CashCtrlApiNet.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
-        <LangVersion>13</LangVersion>
+        <LangVersion>14</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>CashCtrlApiNet.AspNetCore</RootNamespace>

--- a/src/CashCtrlApiNet.IntegrationTests/CashCtrlApiNet.IntegrationTests.csproj
+++ b/src/CashCtrlApiNet.IntegrationTests/CashCtrlApiNet.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
-        <LangVersion>13</LangVersion>
+        <LangVersion>14</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/src/CashCtrlApiNet.UnitTests/CashCtrlApiNet.UnitTests.csproj
+++ b/src/CashCtrlApiNet.UnitTests/CashCtrlApiNet.UnitTests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
-        <LangVersion>13</LangVersion>
+        <LangVersion>14</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/src/CashCtrlApiNet/CashCtrlApiNet.csproj
+++ b/src/CashCtrlApiNet/CashCtrlApiNet.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
-        <LangVersion>13</LangVersion>
+        <LangVersion>14</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>CashCtrlApiNet</RootNamespace>


### PR DESCRIPTION
## Summary\nCloses #46\n\n- **C# 14**: Updated `LangVersion` from `13` to `14` in all 5 `.csproj` files\n- All 914 tests pass (490 unit + 424 integration), build succeeds with 0 warnings\n\n## CI/CD updates needed (manual — PAT lacks `workflow` scope)\n\nThe following workflow changes need to be applied manually or with a token that has the `workflow` scope:\n\n### `.github/workflows/main.yml`\n- `actions/checkout@v2` → `@v4`\n- `NuGet/setup-nuget@v1.0.7` → `@v2`\n- `actions/setup-dotnet@v1` → `@v4`\n- `dotnet-version: 9.x` → `10.x`\n\n### `.github/workflows/sonar-analysis.yml`\n- `actions/setup-java@v3` → `@v4`\n- `actions/checkout@v3` → `@v4`\n- Add `setup-dotnet@v4` step with `dotnet-version: 10.x` (was missing)\n- `actions/cache@v3` → `@v4` (both instances)\n\n## C# 14 feature analysis\n\nThe codebase was reviewed for C# 14 adoption opportunities. Key findings:\n- **`field` keyword**: Not applicable — backing fields are used across constructors and multiple methods, not as simple property-backing fields\n- **Extension types**: Existing static extension methods are clean and well-structured; refactoring to extension types would be gratuitous\n- **Overall**: The codebase already uses modern C# patterns (records, primary constructors, `required`, `init` accessors, `ImmutableArray<T>`). C# 14 is now unlocked for future use of `field` keyword and extension types as the codebase evolves\n\n## Test plan\n- [x] `dotnet build CashCtrlApiNet.sln` — 0 warnings, 0 errors\n- [x] `dotnet build CashCtrlApiNet.sln -c Release` — succeeds, NuGet packages generated\n- [x] Unit tests: 490 passed\n- [x] Integration tests: 424 passed\n\n🤖 Generated with [Claude Code](https://claude.ai/code)