### PR TITLE
Fix Serialize() missing DefaultSerializerOptions

### DIFF
--- a/src/CashCtrlApiNet.Abstractions/Helpers/CashCtrlSerialization.cs
+++ b/src/CashCtrlApiNet.Abstractions/Helpers/CashCtrlSerialization.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 MIT License
 
 Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
@@ -70,7 +70,7 @@ public static class CashCtrlSerialization
     /// <param name="data"></param>
     /// <returns></returns>
     public static string Serialize<TValue>(TValue? data)
-        => JsonSerializer.Serialize(data);
+        => JsonSerializer.Serialize(data, options: DefaultSerializerOptions);
 
     /// <summary>
     /// Convert data object to dictionary

--- a/src/CashCtrlApiNet.UnitTests/Infrastructure/CashCtrlSerializationTests.cs
+++ b/src/CashCtrlApiNet.UnitTests/Infrastructure/CashCtrlSerializationTests.cs
@@ -1,0 +1,69 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using CashCtrlApiNet.Abstractions.Converters;
+using CashCtrlApiNet.Abstractions.Helpers;
+using Shouldly;
+
+namespace CashCtrlApiNet.UnitTests.Infrastructure;
+
+/// <summary>
+/// Regression tests for <see cref="CashCtrlSerialization"/>
+/// </summary>
+public class CashCtrlSerializationTests
+{
+    /// <summary>
+    /// Test record with a DateTime property for serialization verification
+    /// </summary>
+    private record TestModel(DateTime CreatedAt, string? Name);
+
+    [Fact]
+    public void Serialize_ShouldUseCashCtrlDateTimeFormat()
+    {
+        // Arrange
+        var date = new DateTime(2024, 1, 7, 20, 21, 38, 100);
+        var model = new TestModel(date, "Test");
+
+        // Act
+        var result = CashCtrlSerialization.Serialize(model);
+
+        // Assert — must use CashCtrl format (yyyy-MM-dd HH:mm:ss.f), not ISO 8601
+        result.ShouldContain("2024-01-07 20:21:38.1");
+        result.ShouldNotContain("2024-01-07T");
+    }
+
+    [Fact]
+    public void Serialize_ShouldOmitNullProperties()
+    {
+        // Arrange
+        var model = new TestModel(DateTime.Now, null);
+
+        // Act
+        var result = CashCtrlSerialization.Serialize(model);
+
+        // Assert — WhenWritingNull should exclude null fields
+        result.ShouldNotContain("Name");
+    }
+}


### PR DESCRIPTION
## Summary
- `CashCtrlSerialization.Serialize()` was not passing `DefaultSerializerOptions` to `JsonSerializer.Serialize()`, while `Deserialize()` did — causing `CashCtrlDateTimeConverter`, `CashCtrlDateTimeNullableConverter`, and `JsonIgnoreCondition.WhenWritingNull` to be silently skipped for all outgoing request payloads (both POST bodies and GET query parameters via `ConvertToDictionary`).
- Added `options: DefaultSerializerOptions` parameter to the `Serialize()` call.
- Added 2 regression tests verifying DateTime serialization uses the CashCtrl custom format and null properties are omitted.

## Test plan
- [x] All 492 unit tests pass (including 2 new regression tests)
- [x] All 424 integration tests pass
- [ ] Verify DateTime fields in outgoing API requests use `yyyy-MM-dd HH:mm:ss.f` format
- [ ] Verify null fields are excluded from outgoing payloads

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)