### PR TITLE
feat(e2e): implement repeatable e2e test concept with lifecycle management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,17 @@ Design spec: `doc/specs/2026-03-23-full-api-implementation-design.md`
 - **Assertions**: Shouldly (`result.ShouldBe(expected)`)
 - **No live API needed**: All responses are stubbed via WireMock.
 
+### E2E Testing Pattern
+- **Base class**: `CashCtrlE2eTestBase` provides live API client, lifecycle helpers (`GenerateTestId`, `RegisterCleanup`, `RunCleanup`, `AssertSuccess`), and file download support.
+- **Lifecycle**: Each fixture uses `[OneTimeSetUp]` to scavenge orphans and create test data, `[OneTimeTearDown]` to run LIFO cleanup queue.
+- **Test isolation**: All test data uses `"E2E-"` prefix with GUID-based unique test IDs (`GenerateTestId()`). No hardcoded IDs.
+- **Orphan scavenging**: Each `[OneTimeSetUp]` lists entities and deletes any with `"E2E-"` name prefix from previous failed runs.
+- **Cleanup**: `RegisterCleanup(Func<Task>)` adds cleanup actions to a LIFO stack; `RunCleanup()` drains the stack in `[OneTimeTearDown]`, continuing on individual failures.
+- **Assertions**: `AssertSuccess(ApiResult<NoContentResponse>)` validates HTTP success, response data, and no errors. Shouldly for all other assertions.
+- **Ordering**: Tests use `[Order(n)]` for sequencing within a fixture. No `Test1_` prefix — descriptive method names (e.g., `Get_Success`, `Create_DuplicateNrFail`).
+- **No polling loops**: Create returns `InsertId` synchronously; no `Task.Delay` or `CancellationTokenSource(TimeSpan)` patterns.
+- **Requires live API**: E2E tests need `CashCtrlApiNet__BaseUri`, `CashCtrlApiNet__ApiKey`, and optionally `CashCtrlApiNet__Language` environment variables.
+
 ## Important File Locations
 
 | Purpose                          | Path                                                                  |
@@ -171,7 +182,7 @@ Design spec: `doc/specs/2026-03-23-full-api-implementation-design.md`
 ## Known Constraints and Gotchas
 
 1. **E2E tests require a live CashCtrl account** -- E2E tests live in the `CashCtrlApiNet.E2eTests` project (tagged `[Category("E2e")]`) and call the real API. They require environment variables `CashCtrlApiNet__BaseUri`, `CashCtrlApiNet__ApiKey`, and optionally `CashCtrlApiNet__Language`. Unit tests and integration tests run without credentials.
-2. **Test ordering dependency** -- E2E tests in `CashCtrlApiNet.E2eTests` use NUnit's `[Order(n)]` attribute and are named `Test1_`, `Test2_`, etc. to enforce execution order (Create before Delete).
+2. **E2E test lifecycle** -- E2E fixtures use `[OneTimeSetUp]`/`[OneTimeTearDown]` for prepare/cleanup with LIFO cleanup queue. Tests are ordered via `[Order(n)]` with descriptive names (e.g., `Get_Success`). All test data uses `"E2E-"` prefix and GUID-based unique IDs. Orphan scavenging at fixture start cleans stale data from crashed runs.
 3. **Integration tests use WireMock** -- The `CashCtrlApiNet.IntegrationTests` project uses WireMock.Net to simulate the CashCtrl API. Tests inherit from `IntegrationTestBase` which manages the WireMock server lifecycle and creates a real `CashCtrlConnectionHandler` pointed at the mock server.
 4. **`CashCtrlConnectionHandler` supports dual construction** -- Use `IHttpClientFactory` constructor for DI environments (proper connection pooling/lifetime management), or the standalone `ICashCtrlConfiguration`-only constructor for non-DI usage.
 5. **POST uses form-encoded content** -- The CashCtrl API expects `application/x-www-form-urlencoded` for writes, not JSON.

--- a/tests/CashCtrlApiNet.E2eTests/Account/AccountE2eTests.cs
+++ b/tests/CashCtrlApiNet.E2eTests/Account/AccountE2eTests.cs
@@ -29,18 +29,72 @@ using Shouldly;
 namespace CashCtrlApiNet.E2eTests.Account;
 
 /// <summary>
-/// E2E tests for account service
+/// E2E tests for account service with full lifecycle management.
+/// Covers all <see cref="CashCtrlApiNet.Interfaces.Connectors.Account.IAccountService"/> operations.
 /// </summary>
 [Category("E2e")]
 public class AccountE2eTests : CashCtrlE2eTestBase
 {
+    private string _testId = null!;
+    private int _setupAccountId;
+    private int _createdAccountId;
+    private int _accountCategoryId;
+
     /// <summary>
-    /// Get an account successfully
+    /// Scavenges orphan test data and creates the primary test account for the fixture
+    /// </summary>
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _testId = GenerateTestId();
+
+        // Scavenge orphan accounts from previous failed runs
+        var listResult = await CashCtrlApiClient.Account.Account.GetList();
+        if (listResult.ResponseData?.Data is { Length: > 0 } accounts)
+        {
+            var orphanIds = accounts
+                .Where(a => a.Name.StartsWith("E2E-", StringComparison.Ordinal))
+                .Select(a => a.Id)
+                .ToArray();
+
+            if (orphanIds.Length > 0)
+                await CashCtrlApiClient.Account.Account.Delete(new() { Ids = [..orphanIds] });
+        }
+
+        // Discover an account category ID for creating accounts
+        var categoryResult = await CashCtrlApiClient.Account.Category.GetList();
+        _accountCategoryId = categoryResult.ResponseData?.Data.FirstOrDefault()?.Id
+                             ?? throw new InvalidOperationException("No account categories found");
+
+        // Create primary test account with unique number
+        var accountNumber = $"{Random.Shared.Next(99000, 99999)}";
+        var createResult = await CashCtrlApiClient.Account.Account.Create(new()
+        {
+            CategoryId = _accountCategoryId,
+            Name = _testId,
+            Number = accountNumber
+        });
+        createResult.ResponseData.ShouldNotBeNull();
+        createResult.ResponseData.Success.ShouldBeTrue();
+        _setupAccountId = createResult.ResponseData.InsertId
+                          ?? throw new InvalidOperationException("Failed to create setup account");
+
+        RegisterCleanup(async () => await CashCtrlApiClient.Account.Account.Delete(new() { Ids = [_setupAccountId] }));
+    }
+
+    /// <summary>
+    /// Cleans up all test data created during the fixture
+    /// </summary>
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown() => await RunCleanup();
+
+    /// <summary>
+    /// Get an account by ID successfully
     /// </summary>
     [Test, Order(1)]
-    public async Task Test1_Get_Success()
+    public async Task Get_Success()
     {
-        var res = await CashCtrlApiClient.Account.Account.Get(new() { Id = 1 });
+        var res = await CashCtrlApiClient.Account.Account.Get(new() { Id = _setupAccountId });
         res.IsHttpSuccess.ShouldBeTrue();
 
         res.RequestsLeft.ShouldNotBeNull();
@@ -49,15 +103,15 @@ public class AccountE2eTests : CashCtrlE2eTestBase
 
         res.ResponseData.ShouldNotBeNull();
         res.ResponseData.Data.ShouldNotBeNull();
-        res.ResponseData.Data.Name.ShouldNotBeNullOrEmpty();
-        res.ResponseData.Data.Number.ShouldBeGreaterThan("0");
+        res.ResponseData.Data.Name.ShouldBe(_testId);
+        res.ResponseData.Data.Number.ShouldNotBeNullOrEmpty();
     }
 
     /// <summary>
     /// Get list of accounts successfully
     /// </summary>
     [Test, Order(2)]
-    public async Task Test2_GetList_Success()
+    public async Task GetList_Success()
     {
         var res = await CashCtrlApiClient.Account.Account.GetList();
         res.IsHttpSuccess.ShouldBeTrue();
@@ -65,31 +119,33 @@ public class AccountE2eTests : CashCtrlE2eTestBase
         res.ResponseData.ShouldNotBeNull();
         res.ResponseData.Data.Length.ShouldBeGreaterThan(0);
         res.ResponseData.Data.Length.ShouldBe(res.ResponseData.Total);
+        res.ResponseData.Data.ShouldContain(a => a.Id == _setupAccountId);
     }
 
     /// <summary>
     /// Get account balance successfully
     /// </summary>
     [Test, Order(3)]
-    public async Task Test3_GetBalance_Success()
+    public async Task GetBalance_Success()
     {
-        var res = await CashCtrlApiClient.Account.Account.GetBalance(new() { Id = 1 });
+        var res = await CashCtrlApiClient.Account.Account.GetBalance(new() { Id = _setupAccountId });
         res.IsHttpSuccess.ShouldBeTrue();
 
         res.ResponseData.ShouldNotBeNull();
     }
 
     /// <summary>
-    /// Create an account successfully
+    /// Create an account successfully and store its ID for later tests
     /// </summary>
     [Test, Order(4)]
-    public async Task Test4_Create_Success()
+    public async Task Create_Success()
     {
+        var secondAccountNumber = $"{Random.Shared.Next(99000, 99999)}";
         var res = await CashCtrlApiClient.Account.Account.Create(new()
         {
-            CategoryId = 1,
-            Name = "Test E2E Account",
-            Number = "9990"
+            CategoryId = _accountCategoryId,
+            Name = GenerateTestId(),
+            Number = secondAccountNumber
         });
         res.IsHttpSuccess.ShouldBeTrue();
 
@@ -98,70 +154,65 @@ public class AccountE2eTests : CashCtrlE2eTestBase
         res.ResponseData.Errors.ShouldBeNull();
         res.ResponseData.InsertId.ShouldNotBeNull();
         res.ResponseData.InsertId.Value.ShouldBeGreaterThan(0);
+
+        _createdAccountId = res.ResponseData.InsertId.Value;
+        RegisterCleanup(async () => await CashCtrlApiClient.Account.Account.Delete(new() { Ids = [_createdAccountId] }));
     }
 
     /// <summary>
     /// Update an account successfully
     /// </summary>
     [Test, Order(5)]
-    public async Task Test5_Update_Success()
+    public async Task Update_Success()
     {
-        // Find the test account we created
-        AccountListed? account = null;
-        using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20)))
-        {
-            while (account is null && !cts.IsCancellationRequested)
-            {
-                await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
-                account = await GetTestAccount(cts.Token);
-            }
-        }
+        var get = await CashCtrlApiClient.Account.Account.Get(new() { Id = _setupAccountId });
+        var account = get.ResponseData?.Data ?? throw new InvalidOperationException("Failed to get account for update");
 
-        account.ShouldNotBeNull();
-
+        var updatedName = $"{_testId}-Updated";
         var res = await CashCtrlApiClient.Account.Account.Update((account as AccountUpdate) with
         {
-            Name = "Test E2E Account Updated"
+            Name = updatedName
         });
-        res.IsHttpSuccess.ShouldBeTrue();
+        AssertSuccess(res);
 
-        res.ResponseData.ShouldNotBeNull();
-        res.ResponseData.Success.ShouldBeTrue();
-        res.ResponseData.Errors.ShouldBeNull();
+        // Verify the update persisted
+        var verify = await CashCtrlApiClient.Account.Account.Get(new() { Id = _setupAccountId });
+        verify.ResponseData?.Data?.Name.ShouldBe(updatedName);
     }
 
     /// <summary>
-    /// Delete an account successfully
+    /// Categorize an account successfully
     /// </summary>
     [Test, Order(6)]
-    public async Task Test6_Delete_Success()
+    public async Task Categorize_Success()
     {
-        // Wait until test account exists
-        AccountListed? account = null;
-        using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20)))
+        var res = await CashCtrlApiClient.Account.Account.Categorize(new()
         {
-            while (account is null && !cts.IsCancellationRequested)
-            {
-                await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
-                account = await GetTestAccount(cts.Token);
-            }
-        }
+            Ids = [_setupAccountId],
+            TargetCategoryId = _accountCategoryId
+        });
+        AssertSuccess(res);
+    }
 
-        account.ShouldNotBeNull();
-
-        var res = await CashCtrlApiClient.Account.Account.Delete(new() { Ids = [account.Id] });
-        res.IsHttpSuccess.ShouldBeTrue();
-
-        res.ResponseData.ShouldNotBeNull();
-        res.ResponseData.Success.ShouldBeTrue();
-        res.ResponseData.Errors.ShouldBeNull();
+    /// <summary>
+    /// Update account attachments successfully
+    /// </summary>
+    [Test, Order(7)]
+    public async Task UpdateAttachments_Success()
+    {
+        var res = await CashCtrlApiClient.Account.Account.UpdateAttachments(new()
+        {
+            Id = _setupAccountId,
+            AttachedFileIds = []
+        });
+        AssertSuccess(res);
     }
 
     /// <summary>
     /// Export accounts as Excel successfully
     /// </summary>
-    [Test, Order(7)]
-    public async Task Test7_ExportExcel_Success()
+    [Test, Order(8)]
+    public async Task ExportExcel_Success()
     {
         var res = await CashCtrlApiClient.Account.Account.ExportExcel();
         res.IsHttpSuccess.ShouldBeTrue();
@@ -173,7 +224,47 @@ public class AccountE2eTests : CashCtrlE2eTestBase
         await DownloadFile(res.ResponseData.FileName, res.ResponseData.Data);
     }
 
-    private async Task<AccountListed?> GetTestAccount(CancellationToken cancellationToken)
-        => (await CashCtrlApiClient.Account.Account.GetList(cancellationToken: cancellationToken))
-            .ResponseData?.Data.SingleOrDefault(a => a.Number == "9990");
+    /// <summary>
+    /// Export accounts as CSV successfully
+    /// </summary>
+    [Test, Order(9)]
+    public async Task ExportCsv_Success()
+    {
+        var res = await CashCtrlApiClient.Account.Account.ExportCsv();
+        res.IsHttpSuccess.ShouldBeTrue();
+
+        res.ResponseData.ShouldNotBeNull();
+        res.ResponseData.FileName.ShouldNotBeNullOrEmpty();
+        res.ResponseData.Data.Length.ShouldBeGreaterThan(0);
+
+        await DownloadFile(res.ResponseData.FileName, res.ResponseData.Data);
+    }
+
+    /// <summary>
+    /// Export accounts as PDF successfully
+    /// </summary>
+    [Test, Order(10)]
+    public async Task ExportPdf_Success()
+    {
+        var res = await CashCtrlApiClient.Account.Account.ExportPdf();
+        res.IsHttpSuccess.ShouldBeTrue();
+
+        res.ResponseData.ShouldNotBeNull();
+        res.ResponseData.FileName.ShouldNotBeNullOrEmpty();
+        res.ResponseData.Data.Length.ShouldBeGreaterThan(0);
+
+        await DownloadFile(res.ResponseData.FileName, res.ResponseData.Data);
+    }
+
+    /// <summary>
+    /// Delete the account created in <see cref="Create_Success"/>
+    /// </summary>
+    [Test, Order(11)]
+    public async Task Delete_Success()
+    {
+        _createdAccountId.ShouldBeGreaterThan(0, "Create_Success must run before Delete_Success");
+
+        var res = await CashCtrlApiClient.Account.Account.Delete(new() { Ids = [_createdAccountId] });
+        AssertSuccess(res);
+    }
 }

--- a/tests/CashCtrlApiNet.E2eTests/CashCtrlE2eTestBase.cs
+++ b/tests/CashCtrlApiNet.E2eTests/CashCtrlE2eTestBase.cs
@@ -24,14 +24,17 @@ SOFTWARE.
 */
 
 using CashCtrlApiNet.Abstractions.Enums.Api;
+using CashCtrlApiNet.Abstractions.Models.Api;
 using CashCtrlApiNet.Interfaces;
 using CashCtrlApiNet.Services;
 using CashCtrlApiNet.Services.Connectors;
+using Shouldly;
 
 namespace CashCtrlApiNet.E2eTests;
 
 /// <summary>
-/// Base class for all CashCtrl E2E tests requiring live API credentials
+/// Base class for all CashCtrl E2E tests requiring live API credentials.
+/// Provides lifecycle helpers for test data creation, cleanup, and assertion.
 /// </summary>
 public class CashCtrlE2eTestBase
 {
@@ -39,6 +42,8 @@ public class CashCtrlE2eTestBase
     /// Default instance of CashCtrl API client
     /// </summary>
     protected readonly ICashCtrlApiClient CashCtrlApiClient;
+
+    private readonly Stack<Func<Task>> _cleanupActions = new();
 
     /// <summary>
     /// Setup
@@ -66,6 +71,53 @@ public class CashCtrlE2eTestBase
             new SalaryConnector(connectionHandler));
     }
 
+    /// <summary>
+    /// Generates a unique test identifier with "E2E-" prefix for test data isolation
+    /// </summary>
+    /// <returns>A unique string in the format "E2E-{guid}"</returns>
+    protected static string GenerateTestId() => $"E2E-{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// Registers a cleanup action to be executed during teardown in LIFO order
+    /// </summary>
+    /// <param name="cleanupAction">The async cleanup action to register</param>
+    protected void RegisterCleanup(Func<Task> cleanupAction) => _cleanupActions.Push(cleanupAction);
+
+    /// <summary>
+    /// Executes all registered cleanup actions in LIFO order, continuing on individual failures
+    /// </summary>
+    protected async Task RunCleanup()
+    {
+        while (_cleanupActions.TryPop(out var action))
+        {
+            try
+            {
+                await action();
+            }
+            catch (Exception ex)
+            {
+                await TestContext.Out.WriteLineAsync($"Cleanup action failed: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Asserts that a <see cref="NoContentResponse"/> API result indicates success with no errors
+    /// </summary>
+    /// <param name="result">The API result to validate</param>
+    protected static void AssertSuccess(ApiResult<NoContentResponse> result)
+    {
+        result.IsHttpSuccess.ShouldBeTrue();
+        result.ResponseData.ShouldNotBeNull();
+        result.ResponseData.Success.ShouldBeTrue();
+        result.ResponseData.Errors.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Downloads a file to the user's Downloads folder if downloads are enabled
+    /// </summary>
+    /// <param name="fileName">The file name to save as</param>
+    /// <param name="data">The file content bytes</param>
     protected async Task DownloadFile(string fileName, byte[] data)
     {
         if (!IsDownloadsEnabled)

--- a/tests/CashCtrlApiNet.E2eTests/Inventory/ArticleCategoryE2eTests.cs
+++ b/tests/CashCtrlApiNet.E2eTests/Inventory/ArticleCategoryE2eTests.cs
@@ -29,18 +29,63 @@ using Shouldly;
 namespace CashCtrlApiNet.E2eTests.Inventory;
 
 /// <summary>
-/// E2E tests for inventory article category service
+/// E2E tests for inventory article category service with full lifecycle management.
+/// Covers all <see cref="CashCtrlApiNet.Interfaces.Connectors.Inventory.IArticleCategoryService"/> operations.
 /// </summary>
 [Category("E2e")]
 public class ArticleCategoryE2eTests : CashCtrlE2eTestBase
 {
+    private string _testId = null!;
+    private int _setupCategoryId;
+    private int _createdCategoryId;
+
     /// <summary>
-    /// Get an article successfully
+    /// Scavenges orphan test data and creates the primary test category for the fixture
+    /// </summary>
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _testId = GenerateTestId();
+
+        // Scavenge orphan article categories from previous failed runs
+        var listResult = await CashCtrlApiClient.Inventory.ArticleCategory.GetList();
+        if (listResult.ResponseData?.Data is { Length: > 0 } categories)
+        {
+            var orphanIds = categories
+                .Where(c => c.Name.StartsWith("E2E-", StringComparison.Ordinal))
+                .Select(c => c.Id)
+                .ToArray();
+
+            if (orphanIds.Length > 0)
+                await CashCtrlApiClient.Inventory.ArticleCategory.Delete(new() { Ids = [..orphanIds] });
+        }
+
+        // Create primary test category
+        var createResult = await CashCtrlApiClient.Inventory.ArticleCategory.Create(new()
+        {
+            Name = _testId
+        });
+        createResult.ResponseData.ShouldNotBeNull();
+        createResult.ResponseData.Success.ShouldBeTrue();
+        _setupCategoryId = createResult.ResponseData.InsertId
+                           ?? throw new InvalidOperationException("Failed to create setup article category");
+
+        RegisterCleanup(async () => await CashCtrlApiClient.Inventory.ArticleCategory.Delete(new() { Ids = [_setupCategoryId] }));
+    }
+
+    /// <summary>
+    /// Cleans up all test data created during the fixture
+    /// </summary>
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown() => await RunCleanup();
+
+    /// <summary>
+    /// Get an article category by ID successfully
     /// </summary>
     [Test, Order(1)]
-    public async Task Test1_Get_Success()
+    public async Task Get_Success()
     {
-        var res = await CashCtrlApiClient.Inventory.ArticleCategory.Get(new(){ Id = 1 });
+        var res = await CashCtrlApiClient.Inventory.ArticleCategory.Get(new() { Id = _setupCategoryId });
         res.IsHttpSuccess.ShouldBeTrue();
 
         res.RequestsLeft.ShouldNotBeNull();
@@ -49,14 +94,14 @@ public class ArticleCategoryE2eTests : CashCtrlE2eTestBase
 
         res.ResponseData.ShouldNotBeNull();
         res.ResponseData.Data.ShouldNotBeNull();
-        res.ResponseData.Data.Name.ShouldNotBeNullOrEmpty();
+        res.ResponseData.Data.Name.ShouldBe(_testId);
     }
 
     /// <summary>
-    /// Get list of articles successfully
+    /// Get list of article categories successfully
     /// </summary>
     [Test, Order(2)]
-    public async Task Test2_GetList_Success()
+    public async Task GetList_Success()
     {
         var res = await CashCtrlApiClient.Inventory.ArticleCategory.GetList();
         res.IsHttpSuccess.ShouldBeTrue();
@@ -64,17 +109,32 @@ public class ArticleCategoryE2eTests : CashCtrlE2eTestBase
         res.ResponseData.ShouldNotBeNull();
         res.ResponseData.Data.Length.ShouldBeGreaterThan(0);
         res.ResponseData.Data.Length.ShouldBe(res.ResponseData.Total);
+        res.ResponseData.Data.ShouldContain(c => c.Id == _setupCategoryId);
     }
 
     /// <summary>
-    /// Create an article successfully
+    /// Get article category tree successfully
+    /// </summary>
+    [Test, Order(3)]
+    public async Task GetTree_Success()
+    {
+        var res = await CashCtrlApiClient.Inventory.ArticleCategory.GetTree();
+        res.IsHttpSuccess.ShouldBeTrue();
+
+        res.ResponseData.ShouldNotBeNull();
+        res.ResponseData.Data.Length.ShouldBeGreaterThan(0);
+    }
+
+    /// <summary>
+    /// Create an article category successfully and store its ID for later tests
     /// </summary>
     [Test, Order(4)]
-    public async Task Test4_Create_Success()
+    public async Task Create_Success()
     {
+        var secondTestId = GenerateTestId();
         var res = await CashCtrlApiClient.Inventory.ArticleCategory.Create(new()
         {
-            Name = "Test created"
+            Name = secondTestId
         });
         res.IsHttpSuccess.ShouldBeTrue();
 
@@ -83,64 +143,42 @@ public class ArticleCategoryE2eTests : CashCtrlE2eTestBase
         res.ResponseData.Errors.ShouldBeNull();
         res.ResponseData.InsertId.ShouldNotBeNull();
         res.ResponseData.InsertId.Value.ShouldBeGreaterThan(0);
-        res.ResponseData.Message.ShouldBe("Category saved");
+        res.ResponseData.Message.ShouldNotBeNullOrEmpty();
+
+        _createdCategoryId = res.ResponseData.InsertId.Value;
+        RegisterCleanup(async () => await CashCtrlApiClient.Inventory.ArticleCategory.Delete(new() { Ids = [_createdCategoryId] }));
     }
 
     /// <summary>
-    /// Update an article successfully
+    /// Update an article category successfully
     /// </summary>
     [Test, Order(5)]
-    public async Task? Test5_Update_Success()
+    public async Task Update_Success()
     {
-        var get = await CashCtrlApiClient.Inventory.ArticleCategory.Get(new(){ Id = 6 });
-        var articleCategory = get.ResponseData?.Data ?? throw new InvalidOperationException("Failed to get article category");
+        var get = await CashCtrlApiClient.Inventory.ArticleCategory.Get(new() { Id = _setupCategoryId });
+        var category = get.ResponseData?.Data ?? throw new InvalidOperationException("Failed to get article category for update");
 
-        var res = await CashCtrlApiClient.Inventory.ArticleCategory.Update((articleCategory as ArticleCategoryUpdate) with
+        var updatedName = $"{_testId}-Updated";
+        var res = await CashCtrlApiClient.Inventory.ArticleCategory.Update((category as ArticleCategoryUpdate) with
         {
-            Name = "Test updated"
+            Name = updatedName
         });
-        res.IsHttpSuccess.ShouldBeTrue();
+        AssertSuccess(res);
 
-        res.ResponseData.ShouldNotBeNull();
-        res.ResponseData.Success.ShouldBeTrue();
-        res.ResponseData.Errors.ShouldBeNull();
-        res.ResponseData.InsertId.ShouldNotBeNull();
-        res.ResponseData.InsertId.Value.ShouldBeGreaterThan(0);
-        res.ResponseData.Message.ShouldBe("Category saved");
+        // Verify the update persisted
+        var verify = await CashCtrlApiClient.Inventory.ArticleCategory.Get(new() { Id = _setupCategoryId });
+        verify.ResponseData?.Data?.Name.ShouldBe(updatedName);
     }
 
     /// <summary>
-    /// Delete an article successfully
+    /// Delete the article category created in <see cref="Create_Success"/>
     /// </summary>
     [Test, Order(6)]
-    public async Task Test6_Delete_Success()
+    public async Task Delete_Success()
     {
-        // Wait until test article created
-        ArticleCategory? articleCategory = null;
+        _createdCategoryId.ShouldBeGreaterThan(0, "Create_Success must run before Delete_Success");
 
-        using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20)))
-        {
-            while (articleCategory is null && !cts.IsCancellationRequested)
-            {
-                await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
-                articleCategory = await Get(cts.Token);
-            }
-        }
-
-        articleCategory.ShouldNotBeNull();
-
-        // Then delete it
-        var res = await CashCtrlApiClient.Inventory.ArticleCategory.Delete(new(){ Ids = [articleCategory.Id]});
-        res.IsHttpSuccess.ShouldBeTrue();
-
-        res.ResponseData.ShouldNotBeNull();
-        res.ResponseData.Success.ShouldBeTrue();
-        res.ResponseData.Errors.ShouldBeNull();
-        res.ResponseData.Message.ShouldBe("1 category deleted");
-        return;
-
-        // Local function to get article
-        async Task<ArticleCategory?> Get(CancellationToken cancellationToken)
-            => (await CashCtrlApiClient.Inventory.ArticleCategory.GetList(cancellationToken: cancellationToken)).ResponseData?.Data.SingleOrDefault(a => a.Name.Equals("Test created"));
+        var res = await CashCtrlApiClient.Inventory.ArticleCategory.Delete(new() { Ids = [_createdCategoryId] });
+        AssertSuccess(res);
     }
 }

--- a/tests/CashCtrlApiNet.E2eTests/Inventory/ArticleE2eTests.cs
+++ b/tests/CashCtrlApiNet.E2eTests/Inventory/ArticleE2eTests.cs
@@ -29,18 +29,70 @@ using Shouldly;
 namespace CashCtrlApiNet.E2eTests.Inventory;
 
 /// <summary>
-/// E2E tests for inventory article service
+/// E2E tests for inventory article service with full lifecycle management.
+/// Covers all <see cref="CashCtrlApiNet.Interfaces.Connectors.Inventory.IArticleService"/> operations.
 /// </summary>
 [Category("E2e")]
 public class ArticleE2eTests : CashCtrlE2eTestBase
 {
+    private string _testId = null!;
+    private int _setupArticleId;
+    private int _createdArticleId;
+    private int _categoryId;
+
     /// <summary>
-    /// Get an article successfully
+    /// Scavenges orphan test data and creates the primary test article for the fixture
+    /// </summary>
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _testId = GenerateTestId();
+
+        // Scavenge orphan articles from previous failed runs
+        var listResult = await CashCtrlApiClient.Inventory.Article.GetList();
+        if (listResult.ResponseData?.Data is { Length: > 0 } articles)
+        {
+            var orphanIds = articles
+                .Where(a => a.Name.StartsWith("E2E-", StringComparison.Ordinal))
+                .Select(a => a.Id)
+                .ToArray();
+
+            if (orphanIds.Length > 0)
+                await CashCtrlApiClient.Inventory.Article.Delete(new() { Ids = [..orphanIds] });
+        }
+
+        // Discover a category ID for the categorize test
+        var categoryResult = await CashCtrlApiClient.Inventory.ArticleCategory.GetList();
+        _categoryId = categoryResult.ResponseData?.Data.FirstOrDefault()?.Id
+                      ?? throw new InvalidOperationException("No article categories found for categorize test");
+
+        // Create primary test article
+        var createResult = await CashCtrlApiClient.Inventory.Article.Create(new()
+        {
+            Nr = _testId,
+            Name = _testId
+        });
+        createResult.ResponseData.ShouldNotBeNull();
+        createResult.ResponseData.Success.ShouldBeTrue();
+        _setupArticleId = createResult.ResponseData.InsertId
+                          ?? throw new InvalidOperationException("Failed to create setup article");
+
+        RegisterCleanup(async () => await CashCtrlApiClient.Inventory.Article.Delete(new() { Ids = [_setupArticleId] }));
+    }
+
+    /// <summary>
+    /// Cleans up all test data created during the fixture
+    /// </summary>
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown() => await RunCleanup();
+
+    /// <summary>
+    /// Get an article by ID successfully
     /// </summary>
     [Test, Order(1)]
-    public async Task Test1_Get_Success()
+    public async Task Get_Success()
     {
-        var res = await CashCtrlApiClient.Inventory.Article.Get(new(){ Id = 1 });
+        var res = await CashCtrlApiClient.Inventory.Article.Get(new() { Id = _setupArticleId });
         res.IsHttpSuccess.ShouldBeTrue();
 
         res.RequestsLeft.ShouldNotBeNull();
@@ -49,14 +101,14 @@ public class ArticleE2eTests : CashCtrlE2eTestBase
 
         res.ResponseData.ShouldNotBeNull();
         res.ResponseData.Data.ShouldNotBeNull();
-        res.ResponseData.Data.Name.ShouldNotBeNullOrEmpty();
+        res.ResponseData.Data.Name.ShouldBe(_testId);
     }
 
     /// <summary>
     /// Get list of articles successfully
     /// </summary>
     [Test, Order(2)]
-    public async Task Test2_GetList_Success()
+    public async Task GetList_Success()
     {
         var res = await CashCtrlApiClient.Inventory.Article.GetList();
         res.IsHttpSuccess.ShouldBeTrue();
@@ -64,18 +116,44 @@ public class ArticleE2eTests : CashCtrlE2eTestBase
         res.ResponseData.ShouldNotBeNull();
         res.ResponseData.Data.Length.ShouldBeGreaterThan(0);
         res.ResponseData.Data.Length.ShouldBe(res.ResponseData.Total);
+        res.ResponseData.Data.ShouldContain(a => a.Id == _setupArticleId);
     }
 
     /// <summary>
-    /// Try to create article with duplicated Nr and fail
+    /// Create an article successfully and store its ID for later tests
     /// </summary>
     [Test, Order(3)]
-    public async Task Test3_Create_DuplicateNrFail()
+    public async Task Create_Success()
+    {
+        var secondTestId = GenerateTestId();
+        var res = await CashCtrlApiClient.Inventory.Article.Create(new()
+        {
+            Nr = secondTestId,
+            Name = secondTestId
+        });
+        res.IsHttpSuccess.ShouldBeTrue();
+
+        res.ResponseData.ShouldNotBeNull();
+        res.ResponseData.Success.ShouldBeTrue();
+        res.ResponseData.Errors.ShouldBeNull();
+        res.ResponseData.InsertId.ShouldNotBeNull();
+        res.ResponseData.InsertId.Value.ShouldBeGreaterThan(0);
+        res.ResponseData.Message.ShouldNotBeNullOrEmpty();
+
+        _createdArticleId = res.ResponseData.InsertId.Value;
+        RegisterCleanup(async () => await CashCtrlApiClient.Inventory.Article.Delete(new() { Ids = [_createdArticleId] }));
+    }
+
+    /// <summary>
+    /// Try to create article with duplicate Nr and verify error response
+    /// </summary>
+    [Test, Order(4)]
+    public async Task Create_DuplicateNrFail()
     {
         var res = await CashCtrlApiClient.Inventory.Article.Create(new()
         {
-            Nr = "A-00001",
-            Name = "Test"
+            Nr = _testId,
+            Name = $"{_testId}-Duplicate"
         });
         res.IsHttpSuccess.ShouldBeTrue();
 
@@ -84,121 +162,115 @@ public class ArticleE2eTests : CashCtrlE2eTestBase
         res.ResponseData.InsertId.ShouldBeNull();
 
         res.ResponseData.Errors.ShouldNotBeNull();
-        res.ResponseData.Errors.Value.ShouldContain(apiError
-            => apiError.Field.Equals("nr")
-               && apiError.Message.Equals("This article no. is already used by another article."));
-    }
-
-    /// <summary>
-    /// Create an article successfully
-    /// </summary>
-    [Test, Order(4)]
-    public async Task Test4_Create_Success()
-    {
-        var res = await CashCtrlApiClient.Inventory.Article.Create(new()
-        {
-            Nr = "A-00005",
-            Name = "Test created"
-        });
-        res.IsHttpSuccess.ShouldBeTrue();
-
-        res.ResponseData.ShouldNotBeNull();
-        res.ResponseData.Success.ShouldBeTrue();
-        res.ResponseData.Errors.ShouldBeNull();
-        res.ResponseData.InsertId.ShouldNotBeNull();
-        res.ResponseData.InsertId.Value.ShouldBeGreaterThan(0);
-        res.ResponseData.Message.ShouldBe("Article saved");
+        res.ResponseData.Errors.Value.ShouldContain(e => e.Field == "nr");
     }
 
     /// <summary>
     /// Update an article successfully
     /// </summary>
     [Test, Order(5)]
-    public async Task? Test5_Update_Success()
+    public async Task Update_Success()
     {
-        var get = await CashCtrlApiClient.Inventory.Article.Get(new(){ Id = 1 });
-        var article = get.ResponseData?.Data ?? throw new InvalidOperationException("Failed to get article");
+        var get = await CashCtrlApiClient.Inventory.Article.Get(new() { Id = _setupArticleId });
+        var article = get.ResponseData?.Data ?? throw new InvalidOperationException("Failed to get article for update");
 
+        var updatedName = $"{_testId}-Updated";
         var res = await CashCtrlApiClient.Inventory.Article.Update((article as ArticleUpdate) with
         {
-            Name = "Test updated"
+            Name = updatedName
         });
-        res.IsHttpSuccess.ShouldBeTrue();
+        AssertSuccess(res);
 
-        res.ResponseData.ShouldNotBeNull();
-        res.ResponseData.Success.ShouldBeTrue();
-        res.ResponseData.Errors.ShouldBeNull();
-        res.ResponseData.InsertId.ShouldNotBeNull();
-        res.ResponseData.InsertId.Value.ShouldBeGreaterThan(0);
-        res.ResponseData.Message.ShouldBe("Article saved");
+        // Verify the update persisted
+        var verify = await CashCtrlApiClient.Inventory.Article.Get(new() { Id = _setupArticleId });
+        verify.ResponseData?.Data?.Name.ShouldBe(updatedName);
     }
 
     /// <summary>
-    /// Delete an article successfully
+    /// Categorize an article successfully
     /// </summary>
     [Test, Order(6)]
-    public async Task Test6_Delete_Success()
-    {
-        // Wait until test article created
-        ArticleListed? article = null;
-
-        using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
-        {
-            while (article is null && !cts.IsCancellationRequested)
-            {
-                await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
-                article = await Get(cts.Token);
-            }
-        }
-
-        article.ShouldNotBeNull();
-
-        // Then delete it
-        var res = await CashCtrlApiClient.Inventory.Article.Delete(new() { Ids = [article.Id] });
-        res.IsHttpSuccess.ShouldBeTrue();
-
-        res.ResponseData.ShouldNotBeNull();
-        res.ResponseData.Success.ShouldBeTrue();
-        res.ResponseData.Errors.ShouldBeNull();
-        res.ResponseData.Message.ShouldBe("1 article deleted");
-        return;
-
-        // Local function to get article
-        async Task<ArticleListed?> Get(CancellationToken cancellationToken)
-            => (await CashCtrlApiClient.Inventory.Article.GetList(cancellationToken: cancellationToken)).ResponseData?.Data.SingleOrDefault(a => a.Nr.Equals("A-00005"));
-    }
-
-    [Test, Order(7)]
-    public async Task Test7_Categorize_Success()
+    public async Task Categorize_Success()
     {
         var res = await CashCtrlApiClient.Inventory.Article.Categorize(new()
         {
-            Ids = [1],
-            TargetCategoryId = 1
+            Ids = [_setupArticleId],
+            TargetCategoryId = _categoryId
         });
-        res.IsHttpSuccess.ShouldBeTrue();
-
-        res.ResponseData.ShouldNotBeNull();
-        res.ResponseData.Success.ShouldBeTrue();
-        res.ResponseData.Errors.ShouldBeNull();
-        res.ResponseData.InsertId.ShouldBeNull();
-        res.ResponseData.Message.ShouldBe("1 article assigned to category 'Dienstleistungen'");
+        AssertSuccess(res);
     }
 
-    [Test, Order(8)]
-    public async Task Test8_UpdateAttachments_Success()
+    /// <summary>
+    /// Update article attachments successfully
+    /// </summary>
+    [Test, Order(7)]
+    public async Task UpdateAttachments_Success()
     {
         var res = await CashCtrlApiClient.Inventory.Article.UpdateAttachments(new()
         {
-            Id = 1,
-            AttachedFileIds = [3]
+            Id = _setupArticleId,
+            AttachedFileIds = []
         });
+        AssertSuccess(res);
+    }
+
+    /// <summary>
+    /// Export articles as Excel successfully
+    /// </summary>
+    [Test, Order(8)]
+    public async Task ExportExcel_Success()
+    {
+        var res = await CashCtrlApiClient.Inventory.Article.ExportExcel();
         res.IsHttpSuccess.ShouldBeTrue();
 
         res.ResponseData.ShouldNotBeNull();
-        res.ResponseData.Success.ShouldBeTrue();
-        res.ResponseData.Errors.ShouldBeNull();
-        res.ResponseData.InsertId.ShouldBeNull();
-        res.ResponseData.Message.ShouldBe("Attachments saved");
+        res.ResponseData.FileName.ShouldNotBeNullOrEmpty();
+        res.ResponseData.Data.Length.ShouldBeGreaterThan(0);
+
+        await DownloadFile(res.ResponseData.FileName, res.ResponseData.Data);
+    }
+
+    /// <summary>
+    /// Export articles as CSV successfully
+    /// </summary>
+    [Test, Order(9)]
+    public async Task ExportCsv_Success()
+    {
+        var res = await CashCtrlApiClient.Inventory.Article.ExportCsv();
+        res.IsHttpSuccess.ShouldBeTrue();
+
+        res.ResponseData.ShouldNotBeNull();
+        res.ResponseData.FileName.ShouldNotBeNullOrEmpty();
+        res.ResponseData.Data.Length.ShouldBeGreaterThan(0);
+
+        await DownloadFile(res.ResponseData.FileName, res.ResponseData.Data);
+    }
+
+    /// <summary>
+    /// Export articles as PDF successfully
+    /// </summary>
+    [Test, Order(10)]
+    public async Task ExportPdf_Success()
+    {
+        var res = await CashCtrlApiClient.Inventory.Article.ExportPdf();
+        res.IsHttpSuccess.ShouldBeTrue();
+
+        res.ResponseData.ShouldNotBeNull();
+        res.ResponseData.FileName.ShouldNotBeNullOrEmpty();
+        res.ResponseData.Data.Length.ShouldBeGreaterThan(0);
+
+        await DownloadFile(res.ResponseData.FileName, res.ResponseData.Data);
+    }
+
+    /// <summary>
+    /// Delete the article created in <see cref="Create_Success"/>
+    /// </summary>
+    [Test, Order(11)]
+    public async Task Delete_Success()
+    {
+        _createdArticleId.ShouldBeGreaterThan(0, "Create_Success must run before Delete_Success");
+
+        var res = await CashCtrlApiClient.Inventory.Article.Delete(new() { Ids = [_createdArticleId] });
+        AssertSuccess(res);
     }
 }


### PR DESCRIPTION
## Summary

- Redesign e2e test infrastructure with `[OneTimeSetUp]`/`[OneTimeTearDown]` lifecycle pattern for prepare/cleanup
- Enhanced `CashCtrlE2eTestBase` with `GenerateTestId()`, `RegisterCleanup()`, `RunCleanup()`, `AssertSuccess()` helpers
- Rewrite all 3 existing e2e test fixtures: `ArticleE2eTests` (11 tests), `ArticleCategoryE2eTests` (6 tests), `AccountE2eTests` (11 tests)
- GUID-based unique test IDs with `"E2E-"` prefix for collision-free repeatability across runs
- Orphan scavenging at fixture start cleans stale data from crashed/failed runs
- Eliminate all hardcoded IDs (`Id = 1`, `CategoryId = 1`, `Nr = "A-00005"`) and polling loops
- Dynamic category/ID discovery via API calls instead of hardcoded values
- Update CLAUDE.md with new e2e testing pattern documentation

## Verification

| Check | Result |
|-------|--------|
| Build | 0 errors, 0 warnings |
| Unit tests | 503 passed, 0 failed |
| Integration tests | 447 passed, 0 failed |
| E2E tests | Compile-verified (requires live CashCtrl credentials for execution) |
| Code review | APPROVED — no critical issues |

## Test plan

- [ ] Verify solution builds: `dotnet build CashCtrlApiNet.sln`
- [ ] Verify unit tests pass: `dotnet test tests/CashCtrlApiNet.UnitTests/`
- [ ] Verify integration tests pass: `dotnet test tests/CashCtrlApiNet.IntegrationTests/`
- [ ] Manual: Run e2e tests against live CashCtrl test account to verify repeatability
- [ ] Manual: Run e2e tests twice in succession to confirm cleanup works

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)