### PR TITLE
Add HTTP resilience via Microsoft.Extensions.Http.Resilience

### DIFF
--- a/src/CashCtrlApiNet.AspNetCore/CashCtrlApiNet.AspNetCore.csproj
+++ b/src/CashCtrlApiNet.AspNetCore/CashCtrlApiNet.AspNetCore.csproj
@@ -20,6 +20,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+      <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
     </ItemGroup>
 

--- a/src/CashCtrlApiNet.AspNetCore/CashCtrlOptions.cs
+++ b/src/CashCtrlApiNet.AspNetCore/CashCtrlOptions.cs
@@ -51,4 +51,10 @@ public class CashCtrlOptions
     /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#lang">API Doc - Language</a>
     /// </summary>
     public Language Language { get; set; } = Language.De;
+
+    /// <summary>
+    /// Enables HTTP resilience (retries, circuit breaker, timeouts) via the standard resilience handler.
+    /// Defaults to <c>true</c>.
+    /// </summary>
+    public bool EnableResilience { get; set; } = true;
 }

--- a/src/CashCtrlApiNet.AspNetCore/CashCtrlServiceCollectionExtensions.cs
+++ b/src/CashCtrlApiNet.AspNetCore/CashCtrlServiceCollectionExtensions.cs
@@ -61,8 +61,17 @@ public static class CashCtrlServiceCollectionExtensions
         // Register configuration adapter
         services.AddSingleton<ICashCtrlConfiguration, CashCtrlOptionsAdapter>();
 
-        // Register IHttpClientFactory and connection handler
-        services.AddHttpClient();
+        // Register named HttpClient with optional resilience handler
+        var options = new CashCtrlOptions();
+        configureOptions(options);
+
+        var httpClientBuilder = services.AddHttpClient(nameof(CashCtrlConnectionHandler));
+
+        if (options.EnableResilience)
+        {
+            httpClientBuilder.AddStandardResilienceHandler();
+        }
+
         services.AddScoped<ICashCtrlConnectionHandler, CashCtrlConnectionHandler>();
 
         // Register all connectors


### PR DESCRIPTION
## Summary

- Adds `Microsoft.Extensions.Http.Resilience` (v10.4.0) to `CashCtrlApiNet.AspNetCore`, wiring `.AddStandardResilienceHandler()` on the named `HttpClient` used by `CashCtrlConnectionHandler`
- Resilience (retries, circuit breaker, timeouts) is enabled by default via `CashCtrlOptions.EnableResilience` and can be opted out
- Named client registration now matches the existing `CreateClient(nameof(CashCtrlConnectionHandler))` call — previously used the generic `AddHttpClient()` overload

## Changes

| File | Change |
|------|--------|
| `CashCtrlApiNet.AspNetCore.csproj` | Added `Microsoft.Extensions.Http.Resilience` v10.4.0 |
| `CashCtrlOptions.cs` | Added `EnableResilience` property (default: `true`) |
| `CashCtrlServiceCollectionExtensions.cs` | Named client registration + conditional resilience handler |

## Verification

- Build: 0 errors
- Unit tests: 605 passed, 0 failed
- Integration tests: 447 passed, 0 failed
- Verification agent: **APPROVED** — all 8 acceptance criteria met

Closes #96