### PR TITLE
fix: make ApiResult.RequestsLeft init-only and add NuGet package readme

### DIFF
--- a/src/CashCtrlApiNet.Abstractions/CashCtrlApiNet.Abstractions.csproj
+++ b/src/CashCtrlApiNet.Abstractions/CashCtrlApiNet.Abstractions.csproj
@@ -16,7 +16,12 @@
         <RepositoryType>git</RepositoryType>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
+
+    <ItemGroup>
+      <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    </ItemGroup>
 
     <ItemGroup>
       <Folder Include="Models\Common\" />

--- a/src/CashCtrlApiNet.Abstractions/Models/Api/ApiResult.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Api/ApiResult.cs
@@ -51,7 +51,7 @@ public record ApiResult
     /// <summary>
     /// Number of requests left on the API. Not documented, not sure how often this resets.
     /// </summary>
-    public int? RequestsLeft { get; set; }
+    public int? RequestsLeft { get; init; }
 }
 
 /// <summary>

--- a/src/CashCtrlApiNet.AspNetCore/CashCtrlApiNet.AspNetCore.csproj
+++ b/src/CashCtrlApiNet.AspNetCore/CashCtrlApiNet.AspNetCore.csproj
@@ -16,7 +16,12 @@
         <RepositoryType>git</RepositoryType>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
+
+    <ItemGroup>
+      <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    </ItemGroup>
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />

--- a/src/CashCtrlApiNet/CashCtrlApiNet.csproj
+++ b/src/CashCtrlApiNet/CashCtrlApiNet.csproj
@@ -16,7 +16,12 @@
         <RepositoryType>git</RepositoryType>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
+
+    <ItemGroup>
+      <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\CashCtrlApiNet.Abstractions\CashCtrlApiNet.Abstractions.csproj" />

--- a/tests/CashCtrlApiNet.UnitTests/Infrastructure/ApiResultImmutabilityTests.cs
+++ b/tests/CashCtrlApiNet.UnitTests/Infrastructure/ApiResultImmutabilityTests.cs
@@ -1,0 +1,74 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using CashCtrlApiNet.Abstractions.Models.Api;
+using Shouldly;
+
+namespace CashCtrlApiNet.UnitTests.Infrastructure;
+
+/// <summary>
+/// Tests for <see cref="ApiResult"/> immutability — all properties should use init-only setters
+/// </summary>
+public class ApiResultImmutabilityTests
+{
+    /// <summary>
+    /// Verifies that RequestsLeft uses an init-only setter, not a mutable set accessor
+    /// </summary>
+    [Test]
+    public void RequestsLeft_ShouldHaveInitOnlySetter()
+    {
+        var property = typeof(ApiResult).GetProperty(nameof(ApiResult.RequestsLeft));
+        property.ShouldNotBeNull();
+
+        var setter = property.SetMethod;
+        setter.ShouldNotBeNull();
+
+        // Init-only setters have the IsExternalInit modreq on their return parameter
+        var modifiers = setter.ReturnParameter.GetRequiredCustomModifiers();
+        modifiers.ShouldContain(typeof(IsExternalInit),
+            "RequestsLeft should use { get; init; } not { get; set; }");
+    }
+
+    /// <summary>
+    /// Verifies that all ApiResult properties use init-only setters for immutability
+    /// </summary>
+    [Test]
+    public void AllProperties_ShouldHaveInitOnlySetters()
+    {
+        var properties = typeof(ApiResult).GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        foreach (var property in properties)
+        {
+            var setter = property.SetMethod;
+            if (setter is null) continue;
+
+            var modifiers = setter.ReturnParameter.GetRequiredCustomModifiers();
+            modifiers.ShouldContain(typeof(IsExternalInit),
+                $"{property.Name} should use {{ get; init; }} not {{ get; set; }}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix ApiResult.RequestsLeft immutability:** Changed `{ get; set; }` to `{ get; init; }` — the only mutable property across all 208 model records. All usages in `CashCtrlConnectionHandler` already use object initializer syntax, so no handler changes needed.
- **Add PackageReadmeFile to library .csproj files:** Added `<PackageReadmeFile>README.md</PackageReadmeFile>` and the corresponding `<None Include>` item to all three library projects (`Abstractions`, `CashCtrlApiNet`, `AspNetCore`), eliminating NuGet build warnings.
- **Added regression tests:** Two reflection-based tests verify `RequestsLeft` and all `ApiResult` properties use init-only setters.

## Verification

- Build: succeeded (1 pre-existing CS8602 warning in E2eTests, unrelated)
- Unit tests: 607 passed
- Integration tests: 447 passed
- Verification agent: **APPROVED** — all acceptance criteria met, no issues found

Closes #99