### PR TITLE
fix: handle non-JSON API responses gracefully

### DIFF
--- a/src/CashCtrlApiNet.Abstractions/Models/Api/ApiResult.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Api/ApiResult.cs
@@ -52,6 +52,12 @@ public record ApiResult
     /// Number of requests left on the API. Not documented, not sure how often this resets.
     /// </summary>
     public int? RequestsLeft { get; init; }
+
+    /// <summary>
+    /// Raw response content from the API. Populated when the response body cannot be deserialized as JSON,
+    /// e.g. rate limit messages or HTML error pages.
+    /// </summary>
+    public string? RawResponseContent { get; init; }
 }
 
 /// <summary>

--- a/src/CashCtrlApiNet/Services/CashCtrlConnectionHandler.cs
+++ b/src/CashCtrlApiNet/Services/CashCtrlConnectionHandler.cs
@@ -25,6 +25,7 @@ SOFTWARE.
 
 using System.Net;
 using System.Text;
+using System.Text.Json;
 using System.Web;
 using CashCtrlApiNet.Abstractions.Enums.Api;
 using CashCtrlApiNet.Abstractions.Helpers;
@@ -360,7 +361,9 @@ public class CashCtrlConnectionHandler : ICashCtrlConnectionHandler, IDisposable
     }
 
     /// <summary>
-    /// Get API result with data from http response
+    /// Get API result with data from http response. When the response body is not valid JSON
+    /// (e.g. rate limit messages or HTML error pages), returns an <see cref="ApiResult{T}"/> with
+    /// <c>ResponseData = null</c> and the raw content in <see cref="ApiResult.RawResponseContent"/>.
     /// </summary>
     /// <param name="httpResponseMessage"></param>
     /// <typeparam name="T"></typeparam>
@@ -368,11 +371,22 @@ public class CashCtrlConnectionHandler : ICashCtrlConnectionHandler, IDisposable
     private static async Task<ApiResult<T>> GetApiResult<T>(HttpResponseMessage httpResponseMessage) where T : ApiResponse
     {
         var data = await GetData(httpResponseMessage);
-        var responseData = CashCtrlSerialization.Deserialize<T>(data.Content);
-        return CreateApiResult<T>(data) with
+
+        try
         {
-            ResponseData = responseData
-        };
+            var responseData = CashCtrlSerialization.Deserialize<T>(data.Content);
+            return CreateApiResult<T>(data) with
+            {
+                ResponseData = responseData
+            };
+        }
+        catch (JsonException)
+        {
+            return CreateApiResult<T>(data) with
+            {
+                RawResponseContent = data.Content
+            };
+        }
     }
 
     /// <summary>

--- a/tests/CashCtrlApiNet.IntegrationTests/EdgeCaseIntegrationTests.cs
+++ b/tests/CashCtrlApiNet.IntegrationTests/EdgeCaseIntegrationTests.cs
@@ -23,7 +23,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using System.Text.Json;
 using CashCtrlApiNet.IntegrationTests.Fakers;
 using CashCtrlApiNet.IntegrationTests.Helpers;
 using Shouldly;
@@ -59,25 +58,33 @@ public class EdgeCaseIntegrationTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task Get_WithMalformedJson_ShouldThrowJsonException()
+    public async Task Get_WithMalformedJson_ShouldReturnNullResponseDataWithRawContent()
     {
         // Arrange: respond with invalid JSON
         Server.StubGetJson("/api/v1/account/read.json", "{ this is not valid json }}}");
 
-        // Act & Assert
-        await Should.ThrowAsync<JsonException>(
-            () => Client.Account.Account.Get(new() { Id = 1 }));
+        // Act
+        var result = await Client.Account.Account.Get(new() { Id = 1 });
+
+        // Assert
+        result.IsHttpSuccess.ShouldBeTrue();
+        result.ResponseData.ShouldBeNull();
+        result.RawResponseContent.ShouldBe("{ this is not valid json }}}");
     }
 
     [Test]
-    public async Task GetList_WithMalformedJson_ShouldThrowJsonException()
+    public async Task GetList_WithMalformedJson_ShouldReturnNullResponseDataWithRawContent()
     {
         // Arrange: respond with invalid JSON
         Server.StubGetJson("/api/v1/account/list.json", "<<<not json at all>>>");
 
-        // Act & Assert
-        await Should.ThrowAsync<JsonException>(
-            () => Client.Account.Account.GetList());
+        // Act
+        var result = await Client.Account.Account.GetList();
+
+        // Assert
+        result.IsHttpSuccess.ShouldBeTrue();
+        result.ResponseData.ShouldBeNull();
+        result.RawResponseContent.ShouldBe("<<<not json at all>>>");
     }
 
     [Test]

--- a/tests/CashCtrlApiNet.IntegrationTests/NonJsonResponseHandlingTests.cs
+++ b/tests/CashCtrlApiNet.IntegrationTests/NonJsonResponseHandlingTests.cs
@@ -1,0 +1,209 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Net;
+using CashCtrlApiNet.Abstractions.Models.Api;
+using CashCtrlApiNet.IntegrationTests.Fakers;
+using Shouldly;
+using CashCtrlApiNet.IntegrationTests.Helpers;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+
+namespace CashCtrlApiNet.IntegrationTests;
+
+/// <summary>
+/// Integration tests for handling non-JSON API responses (rate limits, HTML error pages)
+/// </summary>
+public class NonJsonResponseHandlingTests : IntegrationTestBase
+{
+    /// <summary>
+    /// Verify that a rate limit plain text response on a typed GET endpoint does not throw
+    /// </summary>
+    [Test]
+    public async Task GetTyped_RateLimitPlainText_ReturnsApiResultWithNullResponseData()
+    {
+        // Arrange
+        Server
+            .Given(Request.Create().WithPath("/api/v1/inventory/article/read.json").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(429)
+                .WithHeader("Content-Type", "text/plain")
+                .WithHeader("X-CashCtrl-Requests-Left", "0")
+                .WithBody("Calls exceeded. Please retry in a moment."));
+
+        // Act
+        var result = await Client.Inventory.Article.Get(new() { Id = 1 });
+
+        // Assert
+        result.IsHttpSuccess.ShouldBeFalse();
+        result.HttpStatusCode.ShouldBe((HttpStatusCode)429);
+        result.ResponseData.ShouldBeNull();
+        result.RawResponseContent.ShouldBe("Calls exceeded. Please retry in a moment.");
+        result.RequestsLeft.ShouldBe(0);
+    }
+
+    /// <summary>
+    /// Verify that an HTML error page response on a typed GET endpoint does not throw
+    /// </summary>
+    [Test]
+    public async Task GetTyped_HtmlErrorPage_ReturnsApiResultWithNullResponseData()
+    {
+        // Arrange
+        Server
+            .Given(Request.Create().WithPath("/api/v1/inventory/article/read.json").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(502)
+                .WithHeader("Content-Type", "text/html")
+                .WithHeader("X-CashCtrl-Requests-Left", "100")
+                .WithBody("<html><body><h1>502 Bad Gateway</h1></body></html>"));
+
+        // Act
+        var result = await Client.Inventory.Article.Get(new() { Id = 1 });
+
+        // Assert
+        result.IsHttpSuccess.ShouldBeFalse();
+        result.HttpStatusCode.ShouldBe((HttpStatusCode)502);
+        result.ResponseData.ShouldBeNull();
+        result.RawResponseContent.ShouldBe("<html><body><h1>502 Bad Gateway</h1></body></html>");
+    }
+
+    /// <summary>
+    /// Verify that a plain text response on a typed POST endpoint does not throw
+    /// </summary>
+    [Test]
+    public async Task PostTyped_PlainTextResponse_ReturnsApiResultWithNullResponseData()
+    {
+        // Arrange
+        var articleCreate = InventoryFakers.ArticleCreate.Generate();
+        Server
+            .Given(Request.Create().WithPath("/api/v1/inventory/article/create.json").UsingPost())
+            .RespondWith(Response.Create()
+                .WithStatusCode(503)
+                .WithHeader("Content-Type", "text/plain")
+                .WithHeader("X-CashCtrl-Requests-Left", "100")
+                .WithBody("Service Temporarily Unavailable"));
+
+        // Act
+        var result = await Client.Inventory.Article.Create(articleCreate);
+
+        // Assert
+        result.IsHttpSuccess.ShouldBeFalse();
+        result.HttpStatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+        result.ResponseData.ShouldBeNull();
+        result.RawResponseContent.ShouldBe("Service Temporarily Unavailable");
+    }
+
+    /// <summary>
+    /// Verify that a 200 response with non-JSON body does not throw and sets RawResponseContent
+    /// </summary>
+    [Test]
+    public async Task GetTyped_Success200NonJson_ReturnsApiResultWithNullResponseData()
+    {
+        // Arrange
+        Server
+            .Given(Request.Create().WithPath("/api/v1/inventory/article/read.json").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "text/plain")
+                .WithHeader("X-CashCtrl-Requests-Left", "50")
+                .WithBody("Unexpected plain text on success"));
+
+        // Act
+        var result = await Client.Inventory.Article.Get(new() { Id = 1 });
+
+        // Assert
+        result.IsHttpSuccess.ShouldBeTrue();
+        result.ResponseData.ShouldBeNull();
+        result.RawResponseContent.ShouldBe("Unexpected plain text on success");
+    }
+
+    /// <summary>
+    /// Verify that an empty response body on a typed endpoint does not throw
+    /// </summary>
+    [Test]
+    public async Task GetTyped_EmptyBody_ReturnsApiResultWithNullResponseData()
+    {
+        // Arrange
+        Server
+            .Given(Request.Create().WithPath("/api/v1/inventory/article/read.json").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(500)
+                .WithHeader("Content-Type", "application/json")
+                .WithHeader("X-CashCtrl-Requests-Left", "100")
+                .WithBody(""));
+
+        // Act
+        var result = await Client.Inventory.Article.Get(new() { Id = 1 });
+
+        // Assert
+        result.IsHttpSuccess.ShouldBeFalse();
+        result.HttpStatusCode.ShouldBe(HttpStatusCode.InternalServerError);
+        result.ResponseData.ShouldBeNull();
+        result.RawResponseContent.ShouldBe("");
+    }
+
+    /// <summary>
+    /// Verify that a valid JSON response still deserializes normally (no regression)
+    /// </summary>
+    [Test]
+    public async Task GetTyped_ValidJson_DeserializesNormally()
+    {
+        // Arrange
+        var article = InventoryFakers.Article.Generate();
+        Server.StubGetJson("/api/v1/inventory/article/read.json",
+            CashCtrlResponseFactory.SingleResponse(article));
+
+        // Act
+        var result = await Client.Inventory.Article.Get(new() { Id = article.Id });
+
+        // Assert
+        result.IsHttpSuccess.ShouldBeTrue();
+        result.ResponseData.ShouldNotBeNull();
+        result.RawResponseContent.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Verify that the non-generic GetAsync also handles non-JSON gracefully
+    /// </summary>
+    [Test]
+    public async Task GetNonGeneric_NonJsonResponse_ReturnsApiResultWithRawContent()
+    {
+        // Arrange
+        Server
+            .Given(Request.Create().WithPath("/api/v1/inventory/article/read.json").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(429)
+                .WithHeader("Content-Type", "text/plain")
+                .WithHeader("X-CashCtrl-Requests-Left", "0")
+                .WithBody("Rate limited"));
+
+        // Act
+        var result = await ConnectionHandler.GetAsync("api/v1/inventory/article/read.json");
+
+        // Assert
+        result.IsHttpSuccess.ShouldBeFalse();
+        result.HttpStatusCode.ShouldBe((HttpStatusCode)429);
+    }
+}


### PR DESCRIPTION
## Summary

- Wraps `CashCtrlSerialization.Deserialize<T>()` in `GetApiResult<T>` with a `try-catch (JsonException)` so non-JSON responses (rate limits, HTML error pages, malformed JSON) no longer crash the library
- Adds `RawResponseContent` property to `ApiResult` base record, populated only on deserialization failure for diagnostics
- Adds 7 new integration tests covering rate limit (429), HTML error (502), POST plain text (503), non-JSON on 200, empty body (500), valid JSON regression, and non-generic path
- Updates 2 existing `EdgeCaseIntegrationTests` that previously expected `JsonException` to assert the new graceful behavior

## Verification

| Check | Result |
|-------|--------|
| Build (`dotnet build -c Release`) | 0 errors, 0 warnings |
| Unit tests | 631 passed |
| Integration tests | 460 passed (includes 7 new + 2 updated) |
| Acceptance criteria | All 5 met |
| Code review | Approved — minimal, correct, well-tested |

## Test Plan

- [x] `GetApiResult<T>` returns `ApiResult` with `ResponseData = null` and `RawResponseContent` populated on non-JSON input
- [x] Happy path (valid JSON) unaffected — `ResponseData` set, `RawResponseContent = null`
- [x] All 631 unit tests pass
- [x] All 460 integration tests pass (including 7 new non-JSON response tests)
- [x] Build succeeds with zero warnings in Release mode

Closes #111