### PR TITLE
fix(e2e): Group 4 import workflows — async=true, mapping shape, field IDs (#89)

### DIFF
--- a/doc/analysis/2026-03-29-api-doc-discrepancies.md
+++ b/doc/analysis/2026-03-29-api-doc-discrepancies.md
@@ -106,6 +106,28 @@ The `file/prepare.json` endpoint is documented as accepting a `files` TEXT param
 - `file/persist.json` must be called after upload to finalize
 - The `file/get` endpoint returns a **302 redirect** to a pre-authenticated cloud storage URL, not the file content directly
 
+### 9. Undocumented `async=true` required on import Execute
+
+The `inventory/article/import/execute.json` and `person/import/execute.json` endpoints document only `id` (mandatory) and `indexes` (optional). In practice, calling with only those parameters returns HTTP 200 with `{"success":false,"message":"An unexpected error occurred. Please contact support."}` — a masked server-side exception.
+
+The CashCtrl UI always sends `async=true`, which routes to a background-job path that succeeds. The response shape changes too: the async path returns `{"success":true,"attributes":{"progressId":"..."}}` while `insertId` is absent and the imported rows are created asynchronously.
+
+Verified via curl: creating the same article data through `POST /inventory/article/create.json` succeeds, but the import Execute endpoint with just `id` fails with the generic error. Adding `async=true` is the minimal fix.
+
+**Impact:** Execute appears completely broken when called per the docs. Models must include an `Async` parameter, and clients should default to `Async=true`.
+
+### 10. Preview endpoints documented as GET, actually POST
+
+`inventory/article/import/preview.json` and `person/import/preview.json` show `GET` in the docs, but the CashCtrl UI always sends `POST` with `id` in the form body. Both verbs work in practice; matching the UI (`POST`) is the safer choice.
+
+### 11. `mapping_combo.json` field IDs use `UPPER_SNAKE_CASE`
+
+The "List mapping fields" endpoints (`inventory/article/import/mapping_combo.json`, `person/import/mapping_combo.json`) return `{text, value, group}` triples where `value` is an `UPPER_SNAKE_CASE` identifier: `NR`, `NAME_DE`, `NAME_EN`, `FIRST_NAME`, `LAST_NAME`, `ROLE_CUSTOMER`, `CATEGORY_NAME_DE`, etc. These `value` strings are what must appear on the `to` side of each `mapping.json` array entry.
+
+This is the **only** place in the CashCtrl API where `UPPER_SNAKE_CASE` identifiers appear — all other request/response fields use `camelCase`. The docs link to the combo endpoint but never show the response shape, so the casing convention is undiscoverable without a live call.
+
+**Impact:** Inferring field IDs from model property names (e.g., `nr`, `name`, `firstName`) is wrong. Always call `mapping_combo.json` (or inspect the UI payload) to learn the correct `value` strings.
+
 ## Recommendations
 
 1. **Never use `required` on properties that appear in both create requests and read responses**, unless the field name and type are identical in both directions. Use nullable properties and validate at the application level.

--- a/doc/analysis/2026-03-29-e2e-test-verification.md
+++ b/doc/analysis/2026-03-29-e2e-test-verification.md
@@ -14,13 +14,13 @@
 | 1 | Read-only | Report, Organization, History, SalaryField | 5 | **5/5 passed** |
 | 2 | Simple CRUD | Currency, CustomField, CustomFieldGroup, Rounding, SequenceNumber, TaxRate, TextTemplate, PersonTitle, Unit, 6x categories | 86 | **86/86 passed** |
 | 3 | CRUD + exports | Account, AccountBank, CostCenter, Article, FixedAsset, Person, File | 77 | **77/77 passed** |
-| 4 | Import workflows | InventoryImport, PersonImport | ~10 | **blocked — see [2026-04-19 report](2026-04-19-group4-import-e2e-verification.md)** |
+| 4 | Import workflows | InventoryImport, PersonImport | 10 | **10/10 passed** — see [2026-04-19 report](2026-04-19-group4-import-e2e-verification.md) |
 | 5 | Journal | Journal, JournalImport, JournalImportEntry | ~24 | **not yet run** |
 | 6 | Order | OrderCategory, OrderLayout, Order, BookEntry, Document, OrderPayment | ~39 | **not yet run** |
 | 7 | Salary | 15 salary fixtures | ~90 | **not yet run** |
 | 8 | Meta (highest risk) | Settings, Location, FiscalPeriodTask, FiscalPeriod | ~26 | **not yet run** |
 
-**168 passed, 0 skipped, 0 failed.** ~189 tests remaining across Groups 4-8.
+**178 passed, 0 skipped, 0 failed.** ~179 tests remaining across Groups 5-8.
 
 ## What Was Fixed
 

--- a/doc/analysis/2026-04-19-group4-import-e2e-verification.md
+++ b/doc/analysis/2026-04-19-group4-import-e2e-verification.md
@@ -1,94 +1,59 @@
-# Group 4 Import E2E Verification — Status Report
+# Group 4 Import E2E Verification — Final Report
 
 **Date:** 2026-04-19
-**Scope:** Live E2E verification attempt for `InventoryImportE2eTests` and `PersonImportE2eTests`
+**Scope:** Live E2E verification for `InventoryImportE2eTests` and `PersonImportE2eTests`
 **Issue:** #89
-**Status:** Blocked on live credentials (see below)
+**Status:** Complete — 10/10 tests passing
 
 ## Summary
 
-The Group 4 import workflow E2E fixtures (`InventoryImportE2eTests`, `PersonImportE2eTests`) could not be exercised against the live CashCtrl API in this run. The sandbox environment used for the task did not have the required credentials (`CashCtrlApiNet__BaseUri`, `CashCtrlApiNet__ApiKey`). Static analysis and pattern review against Groups 1-3 findings did not surface any obvious defects that warrant speculative code changes without live evidence.
+Both import fixtures now run green against the live CashCtrl API. Fixes span four areas: mapping JSON shape, field ID casing, the undocumented `async=true` requirement on Execute, and test data isolation. This report replaces the initial speculative-risks analysis that was written when live credentials were not available.
 
-No code under `src/` or `tests/CashCtrlApiNet.UnitTests/` or `tests/CashCtrlApiNet.IntegrationTests/` was changed as part of this work. The build remains clean with zero warnings, all 631 unit tests pass, and all 460 integration tests pass.
+## Fixes applied
 
-## Verification Status
+### 1. Mapping JSON shape (`[{from, to}]`)
 
-| Fixture | Tests | Local build | Unit + Integration | Live E2E |
-|---------|-------|-------------|---------------------|---------|
-| `InventoryImportE2eTests` | 5 | passing | supported by 5 unit tests + 5 integration tests | **not run (no credentials)** |
-| `PersonImportE2eTests` | 5 | passing | supported by 5 unit tests + 5 integration tests | **not run (no credentials)** |
+The `mapping` parameter sent to `/inventory/article/import/mapping.json` and `/person/import/mapping.json` is a JSON array of `{"from":"<CSV column>","to":"<field ID>"}` objects. The old tests sent `[{"column":"Nr","field":"nr"}]` (wrong keys) for Inventory and `{"lastName":"lastName"}` (wrong structure — flat object) for Person. XML doc comments on `InventoryImportMapping.Mapping` / `PersonImportMapping.Mapping` now document the required shape.
 
-Attempted live runs both fail during fixture constructor with:
+### 2. Field IDs use `UPPER_SNAKE_CASE`
 
-```
-OneTimeSetUp: SetUp : System.InvalidOperationException : Missing CashCtrlApiNet__BaseUri
-  at CashCtrlApiNet.E2eTests.CashCtrlE2eTestBase..ctor() in CashCtrlE2eTestBase.cs:line 58
-```
+Fields available for import mapping are listed by `mapping_combo.json` and use identifiers like `NR`, `NAME_DE`, `FIRST_NAME`, `LAST_NAME` — not `nr`, `name`, `firstName`, `lastName`. This casing is specific to the two `mapping_combo.json` endpoints; all other API fields use `camelCase`. Documented in [`2026-03-29-api-doc-discrepancies.md`](2026-03-29-api-doc-discrepancies.md) §11.
 
-This is the correct defensive behavior of `CashCtrlE2eTestBase` — it fails fast when environment variables are absent rather than silently testing against an unconfigured base URI.
+### 3. Undocumented `async=true` required on Execute
 
-## Static Review of Architect Concerns
+`execute.json` documents `id` and optional `indexes`, but the sync path returns a generic `{"success":false,"message":"An unexpected error occurred. Please contact support."}` — a masked server exception. The CashCtrl UI always sends `async=true`, which succeeds and returns a `progressId`. `InventoryImportExecute` / `PersonImportExecute` now expose `Async` and `Indexes` properties; both E2E tests set `Async=true`. Documented in [`2026-03-29-api-doc-discrepancies.md`](2026-03-29-api-doc-discrepancies.md) §9.
 
-The architect blueprint flagged six areas that might require fixes based on Groups 1-3 patterns. Each was reviewed:
+### 4. Test data isolation
 
-### FileId (`int` vs other form)
-- `InventoryImportCreate.FileId` and `PersonImportCreate.FileId` are both `required int` with `[JsonPropertyName("fileId")]`.
-- The File service's `Prepare → Persist` flow returns a numeric file ID (`FilePrepareEntry.FileId` is `int`), and the E2E base class helper `UploadTestFile` returns `int`.
-- **Conclusion:** No change. Wiring between File Persist and Import Create is type-consistent. If the live API rejects a numeric file ID, the form-encoded request will surface the error clearly and the model can be updated then.
+- Hardcoded `E2E-IMPORT-001` replaced with `GenerateTestId()` per CLAUDE.md convention.
+- Orphan scavenging in `InventoryImportE2eTests` extended to match articles whose `Name` **or** `Nr` starts with `E2E-`, since earlier broken-mapping runs left orphans with empty names.
+- `PersonImportE2eTests` switched from vCard to CSV source file. The API docs state Mapping is not needed for vCards — testing the Mapping endpoint with a vCard source is meaningless by design.
 
-### Mapping field (`string` vs `JsonElement`)
-- `InventoryImportMapping.Mapping` and `PersonImportMapping.Mapping` are both `required string` with `[JsonPropertyName("mapping")]`.
-- The CashCtrl API docs describe this parameter as `TEXT` accepting a JSON string. The POST body is `application/x-www-form-urlencoded`, produced by `CashCtrlSerialization.ConvertToDictionary`.
-- Empirical verification of STJ's `Dictionary<string, object?>` round-trip shows that a C# `string` holding JSON content (`"[{\"column\":\"Nr\",\"field\":\"nr\"}]"`) serializes to the form-encoded value `mapping=[{"column":"Nr","field":"nr"}]` — which is the expected wire format for a JSON-text TEXT parameter.
-- Switching to `JsonElement?` would also produce compatible output, but offers no semantic advantage on the request side because the Mapping model is write-only (never deserialized from a response).
-- **Conclusion:** No change. The Groups 1-3 `string? → JsonElement?` pattern was applied to fields that appear in both create requests **and** read responses (e.g., `Insurances`, `Elements`, `Custom`, `Allocations`, `Values`) where the response returns an array. Import Mapping models are not part of any read response.
+### 5. Assertion diagnostics
 
-### Response types (`NoContentResponse`)
-- The services currently deserialize `Create`, `Mapping`, `Preview`, and `Execute` responses into `ApiResult<NoContentResponse>`.
-- `NoContentResponse` has fields `{ success, errors, message, insertId }`. Any extra JSON fields in the response (e.g., preview rows, execution stats) are silently ignored by `System.Text.Json` defaults.
-- The existing E2E fixtures only call `AssertSuccess(res)` / `AssertCreated(res)` — they do not need preview rows or stats. Integration tests confirm the success-case deserialization works.
-- **Conclusion:** No change pending live evidence. If future work wants to surface preview rows or execute stats to callers, dedicated response records can be introduced without breaking existing callers.
+`CashCtrlE2eTestBase.AssertSuccess` / `AssertCreated` now surface the response `Message` and `Errors` in the Shouldly failure message. Failure output changed from "True expected, False got" to "API response: Message='...', Errors=[...]", which accelerated the debugging cycle throughout this verification.
 
-### Id fields (`"id"` vs `"importId"`)
-- `InventoryImportMapping.Id`, `InventoryImportPreview.Id`, `InventoryImportExecute.Id`, and Person counterparts all use `[JsonPropertyName("id")]` with `int` type.
-- These are request-side fields only (write-only models). `[JsonNumberHandling]` is relevant for response deserialization only, which does not apply here.
-- The API docs for `/inventory/article/import/mapping.json`, `/inventory/article/import/preview.json`, `/inventory/article/import/execute.json` (and Person equivalents) all document the parameter as `id`, not `importId`.
-- **Conclusion:** No change. If the live API rejects `id` and expects `importId`, that will be obvious in the 400 response body and fix is a one-liner.
+## Non-issues confirmed
 
-### Array vs string response payloads
-- None of the Import models (Create/Mapping/Preview/Execute) are read-response models. They are all write-only request bodies.
-- The `GetMappingFields` endpoint returns JSON that is currently consumed as `ApiResult` (untyped). Integration test confirms deserialization succeeds for `{"data":[{"value":"name","text":"Name"}]}`.
-- **Conclusion:** No change pending live evidence on `GetMappingFields`.
+- **Preview HTTP verb**: docs say `GET`, UI uses `POST`; our library uses `POST`, which works. Documented in [`2026-03-29-api-doc-discrepancies.md`](2026-03-29-api-doc-discrepancies.md) §10.
+- **No hidden required fields on `create.json`** (Inventory or Person) — `fileId` is the only mandatory parameter. Optional `categoryId` exists but is not required.
+- **Parameter name is `id`, not `importId`** on Mapping/Preview/Execute (matches existing code).
+- **No `source` parameter for Person imports** — risk #5 from the initial analysis was unfounded.
 
-### String IDs (`JsonNumberHandling.AllowReadingFromString`)
-- Not applicable — see "Id fields" above.
+## Investigation trail
 
-## What Can Still Go Wrong on Live API (and how to fix)
+Diagnosis was done via a curl reproduction that bypassed the library entirely:
 
-Because live verification was not possible, the following risks remain open. Each is cheap to fix if it materializes:
+1. Replicated the full flow (prepare/persist/create/mapping/execute) with curl — same generic Execute failure, ruling out a library bug.
+2. Created the same target article data directly via `POST /inventory/article/create.json` — succeeded, proving the data was valid.
+3. Inspected the CashCtrl UI's own network traffic during an import — observed `async=true` in the Execute POST body.
+4. Confirmed the fix with a minimal curl call (`id=..., async=true`) and rolled it into the library.
 
-1. **API returns `400 Bad Request` on Create.** Inspect the error payload — likely a required field not documented (e.g., `source`, `name`, `type`). Add to `InventoryImportCreate` / `PersonImportCreate` as `required`.
-2. **API rejects `id` in Mapping/Preview/Execute.** Rename to `importId` in `[JsonPropertyName]` (Abstractions project only, no service/interface changes needed).
-3. **API returns complex JSON from Preview/Execute that breaks deserialization.** Unlikely given STJ's default behavior of ignoring extra properties, but if it returns a non-object top-level (e.g., an array directly), introduce dedicated response types.
-4. **Mapping JSON format differs.** The Inventory test uses an array-of-objects format `[{"column":"Nr","field":"nr"}]` while the Person test uses a flat object `{"lastName":"lastName","firstName":"firstName"}`. One of these may be wrong. The API docs do not specify the exact shape.
-5. **VCF import requires `source` parameter.** Some CashCtrl import endpoints accept a `source` (e.g., `outlook`, `apple`). If the Person Create fails, this is a likely culprit.
+## Test status
 
-## Recommended Next Steps for the Team Leader
+| Fixture | Tests | Status |
+|---------|-------|--------|
+| `InventoryImportE2eTests` | 5 | all green |
+| `PersonImportE2eTests` | 5 | all green |
 
-1. Run E2E tests with live credentials:
-   ```bash
-   export CashCtrlApiNet__BaseUri="https://<org>.cashctrl.com/"
-   export CashCtrlApiNet__ApiKey="<apiKey>"
-   dotnet test tests/CashCtrlApiNet.E2eTests/CashCtrlApiNet.E2eTests.csproj \
-     --filter "FullyQualifiedName~InventoryImportE2eTests|FullyQualifiedName~PersonImportE2eTests"
-   ```
-2. Capture any failures and apply the fix patterns summarized above. If the needed fix is outside the "cheap one-liner" category, hand a focused issue back to the developer agent.
-3. Append findings to this document and `doc/analysis/2026-03-29-e2e-test-verification.md` (Group 4 row) once the live run is complete.
-
-## Environment Notes
-
-- .NET SDK: 10.0
-- Build command: `dotnet build CashCtrlApiNet.sln -p:TreatWarningsAsErrors=true -m:1`
-- Unit tests: `dotnet test tests/CashCtrlApiNet.UnitTests/CashCtrlApiNet.UnitTests.csproj --no-build`
-- Integration tests: `dotnet test tests/CashCtrlApiNet.IntegrationTests/CashCtrlApiNet.IntegrationTests.csproj --no-build`
-- NuGet packages: no outdated packages (confirmed via `dotnet list package --outdated`)
+Unit tests: 631 passing. Integration tests: 453 passing. Build: 0 warnings, 0 errors.

--- a/src/CashCtrlApiNet.Abstractions/Models/Inventory/Import/InventoryImportExecute.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Inventory/Import/InventoryImportExecute.cs
@@ -38,4 +38,19 @@ public record InventoryImportExecute : ModelBaseRecord
     /// </summary>
     [JsonPropertyName("id")]
     public required int Id { get; init; }
+
+    /// <summary>
+    /// Run the import as a background job. Undocumented but required in practice: the synchronous
+    /// path returns a generic "unexpected error" on the live API, while <c>async=true</c> succeeds
+    /// and returns a <c>progressId</c> the caller can poll.
+    /// </summary>
+    [JsonPropertyName("async")]
+    public bool? Async { get; init; }
+
+    /// <summary>
+    /// Zero-based row indexes to import, comma-separated. Only these rows are imported, all others
+    /// ignored. Indexes come from the Preview response. Omit to import all rows.
+    /// </summary>
+    [JsonPropertyName("indexes")]
+    public string? Indexes { get; init; }
 }

--- a/src/CashCtrlApiNet.Abstractions/Models/Inventory/Import/InventoryImportMapping.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Inventory/Import/InventoryImportMapping.cs
@@ -40,7 +40,11 @@ public record InventoryImportMapping : ModelBaseRecord
     public required int Id { get; init; }
 
     /// <summary>
-    /// The mapping of fields as a JSON string.
+    /// The mapping of Excel/CSV columns to CashCtrl fields as a JSON string.
+    /// Expected shape: <c>[{"from":"&lt;column header&gt;","to":"&lt;FIELD_ID&gt;"}, ...]</c>.
+    /// Field IDs are <c>UPPER_SNAKE_CASE</c> (e.g. <c>NR</c>, <c>NAME_DE</c>, <c>CATEGORY_NAME_DE</c>),
+    /// not the camelCase used elsewhere in the API. Enumerate the available IDs via
+    /// <c>/inventory/article/import/mapping_combo.json</c>.
     /// </summary>
     [JsonPropertyName("mapping")]
     public required string Mapping { get; init; }

--- a/src/CashCtrlApiNet.Abstractions/Models/Person/Import/PersonImportExecute.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Person/Import/PersonImportExecute.cs
@@ -38,4 +38,19 @@ public record PersonImportExecute : ModelBaseRecord
     /// </summary>
     [JsonPropertyName("id")]
     public required int Id { get; init; }
+
+    /// <summary>
+    /// Run the import as a background job. Undocumented but required in practice: the synchronous
+    /// path returns a generic "unexpected error" on the live API, while <c>async=true</c> succeeds
+    /// and returns a <c>progressId</c> the caller can poll.
+    /// </summary>
+    [JsonPropertyName("async")]
+    public bool? Async { get; init; }
+
+    /// <summary>
+    /// Zero-based row indexes to import, comma-separated. Only these rows are imported, all others
+    /// ignored. Indexes come from the Preview response. Omit to import all rows.
+    /// </summary>
+    [JsonPropertyName("indexes")]
+    public string? Indexes { get; init; }
 }

--- a/src/CashCtrlApiNet.Abstractions/Models/Person/Import/PersonImportMapping.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Person/Import/PersonImportMapping.cs
@@ -40,7 +40,11 @@ public record PersonImportMapping : ModelBaseRecord
     public required int Id { get; init; }
 
     /// <summary>
-    /// The mapping of fields as a JSON string.
+    /// The mapping of Excel/CSV columns to CashCtrl fields as a JSON string.
+    /// Expected shape: <c>[{"from":"&lt;column header&gt;","to":"&lt;FIELD_ID&gt;"}, ...]</c>.
+    /// Field IDs are <c>UPPER_SNAKE_CASE</c> (e.g. <c>FIRST_NAME</c>, <c>LAST_NAME</c>, <c>COMPANY</c>, <c>ROLE_CUSTOMER</c>),
+    /// not the camelCase used elsewhere in the API. Not needed for vCard imports.
+    /// Enumerate the available IDs via <c>/person/import/mapping_combo.json</c>.
     /// </summary>
     [JsonPropertyName("mapping")]
     public required string Mapping { get; init; }

--- a/tests/CashCtrlApiNet.E2eTests/CashCtrlE2eTestBase.cs
+++ b/tests/CashCtrlApiNet.E2eTests/CashCtrlE2eTestBase.cs
@@ -152,8 +152,9 @@ public class CashCtrlE2eTestBase
     {
         result.IsHttpSuccess.ShouldBeTrue();
         result.ResponseData.ShouldNotBeNull();
-        result.ResponseData.Success.ShouldBeTrue();
-        result.ResponseData.Errors.ShouldBeNull();
+        var details = FormatNoContentResponseDetails(result.ResponseData);
+        result.ResponseData.Success.ShouldBeTrue(details);
+        result.ResponseData.Errors.ShouldBeNull(details);
     }
 
     /// <summary>
@@ -166,11 +167,20 @@ public class CashCtrlE2eTestBase
     {
         result.IsHttpSuccess.ShouldBeTrue();
         result.ResponseData.ShouldNotBeNull();
-        result.ResponseData.Success.ShouldBeTrue();
-        result.ResponseData.Errors.ShouldBeNull();
-        result.ResponseData.InsertId.ShouldNotBeNull();
-        result.ResponseData.InsertId.Value.ShouldBeGreaterThan(0);
+        var details = FormatNoContentResponseDetails(result.ResponseData);
+        result.ResponseData.Success.ShouldBeTrue(details);
+        result.ResponseData.Errors.ShouldBeNull(details);
+        result.ResponseData.InsertId.ShouldNotBeNull(details);
+        result.ResponseData.InsertId.Value.ShouldBeGreaterThan(0, details);
         return result.ResponseData.InsertId.Value;
+    }
+
+    private static string FormatNoContentResponseDetails(NoContentResponse response)
+    {
+        var errors = response.Errors is { Length: > 0 } list
+            ? string.Join("; ", list.Select(e => $"[{e.Field}] {e.Message}"))
+            : "<none>";
+        return $"API response: Message='{response.Message ?? "<null>"}', Errors={errors}";
     }
 
     /// <summary>

--- a/tests/CashCtrlApiNet.E2eTests/Inventory/InventoryImportE2eTests.cs
+++ b/tests/CashCtrlApiNet.E2eTests/Inventory/InventoryImportE2eTests.cs
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+using System.Collections.Immutable;
 using System.Text;
 using Shouldly;
 
@@ -37,6 +38,7 @@ namespace CashCtrlApiNet.E2eTests.Inventory;
 // ReSharper disable once InconsistentNaming
 public class InventoryImportE2eTests : CashCtrlE2eTestBase
 {
+    private string _testId = null!;
     private int _fileId;
     private int _importId;
 
@@ -46,15 +48,27 @@ public class InventoryImportE2eTests : CashCtrlE2eTestBase
     [OneTimeSetUp]
     public async Task OneTimeSetUp()
     {
-        // Scavenge orphan articles that may have been created by previous import runs
-        await ScavengeOrphans(
-            () => CashCtrlApiClient.Inventory.Article.GetList(),
-            a => a.Name,
-            a => a.Id,
-            ids => CashCtrlApiClient.Inventory.Article.Delete(ids));
+        _testId = GenerateTestId();
 
-        // Upload a minimal CSV file for import via UploadTestFile helper
-        var csvContent = "Nr;Name\nE2E-IMPORT-001;E2E-ImportTestArticle";
+        // Scavenge orphan articles that may have been created by previous import runs.
+        // Match by Name OR Nr because earlier broken-mapping runs could leave articles
+        // with no "E2E-" name but an "E2E-" Nr (or vice versa), which a name-only filter misses.
+        var listResult = await CashCtrlApiClient.Inventory.Article.GetList();
+        if (listResult.ResponseData?.Data is { Length: > 0 } items)
+        {
+            var orphanIds = items
+                .Where(a => a.Name.StartsWith("E2E-", StringComparison.Ordinal)
+                         || a.Nr.StartsWith("E2E-", StringComparison.Ordinal))
+                .Select(a => a.Id)
+                .ToImmutableArray();
+
+            if (orphanIds.Length > 0)
+                await CashCtrlApiClient.Inventory.Article.Delete(new() { Ids = orphanIds });
+        }
+
+        // Upload a minimal CSV file with a unique Nr/Name so Execute can't collide with orphans from
+        // prior runs whose name was never populated (broken mapping) and therefore slipped past scavenge.
+        var csvContent = $"Nr;Name\n{_testId};{_testId}";
         _fileId = await UploadTestFile("e2e-import-test.csv", Encoding.UTF8.GetBytes(csvContent), "text/csv");
     }
 
@@ -101,7 +115,7 @@ public class InventoryImportE2eTests : CashCtrlE2eTestBase
         var res = await CashCtrlApiClient.Inventory.Import.Mapping(new()
         {
             Id = _importId,
-            Mapping = "[{\"column\":\"Nr\",\"field\":\"nr\"},{\"column\":\"Name\",\"field\":\"name\"}]"
+            Mapping = "[{\"from\":\"Nr\",\"to\":\"NR\"},{\"from\":\"Name\",\"to\":\"NAME_DE\"}]"
         });
         AssertSuccess(res);
     }
@@ -131,7 +145,8 @@ public class InventoryImportE2eTests : CashCtrlE2eTestBase
 
         var res = await CashCtrlApiClient.Inventory.Import.Execute(new()
         {
-            Id = _importId
+            Id = _importId,
+            Async = true
         });
         AssertSuccess(res);
     }

--- a/tests/CashCtrlApiNet.E2eTests/Person/PersonImportE2eTests.cs
+++ b/tests/CashCtrlApiNet.E2eTests/Person/PersonImportE2eTests.cs
@@ -41,7 +41,9 @@ public class PersonImportE2eTests : CashCtrlE2eTestBase
     private int _importId;
 
     /// <summary>
-    /// Scavenges orphan test data and uploads a VCF file for import tests
+    /// Scavenges orphan test data and uploads a CSV file for import tests.
+    /// CSV (not vCard) is used so the Mapping step is meaningful — the API docs state
+    /// mapping is not needed for vCards, which would make Mapping_Success trivial or fail.
     /// </summary>
     [OneTimeSetUp]
     public async Task OneTimeSetUp()
@@ -55,9 +57,9 @@ public class PersonImportE2eTests : CashCtrlE2eTestBase
             p => p.Id,
             ids => CashCtrlApiClient.Person.Person.Delete(ids));
 
-        // Upload a minimal VCF file for import tests via UploadTestFile helper
-        var vcfContent = $"BEGIN:VCARD\nVERSION:3.0\nN:{_testId};E2E-First\nFN:E2E-First {_testId}\nEND:VCARD";
-        _fileId = await UploadTestFile("e2e-test.vcf", Encoding.UTF8.GetBytes(vcfContent), "text/vcard");
+        // Upload a minimal CSV file with first/last name columns for import via UploadTestFile helper
+        var csvContent = $"First name;Last name\n{_testId};{_testId}";
+        _fileId = await UploadTestFile("e2e-person-import.csv", Encoding.UTF8.GetBytes(csvContent), "text/csv");
 
         // Register cleanup to delete any imported persons after test
         RegisterCleanup(async () =>
@@ -93,7 +95,7 @@ public class PersonImportE2eTests : CashCtrlE2eTestBase
     }
 
     /// <summary>
-    /// Create a person import from uploaded VCF file successfully
+    /// Create a person import from uploaded CSV file successfully
     /// </summary>
     [Test, Order(2)]
     public async Task Create_Success()
@@ -120,7 +122,7 @@ public class PersonImportE2eTests : CashCtrlE2eTestBase
         var res = await CashCtrlApiClient.Person.Import.Mapping(new()
         {
             Id = _importId,
-            Mapping = "{\"lastName\":\"lastName\",\"firstName\":\"firstName\"}"
+            Mapping = "[{\"from\":\"First name\",\"to\":\"FIRST_NAME\"},{\"from\":\"Last name\",\"to\":\"LAST_NAME\"}]"
         });
         AssertSuccess(res);
     }
@@ -150,7 +152,8 @@ public class PersonImportE2eTests : CashCtrlE2eTestBase
 
         var res = await CashCtrlApiClient.Person.Import.Execute(new()
         {
-            Id = _importId
+            Id = _importId,
+            Async = true
         });
         AssertSuccess(res);
     }


### PR DESCRIPTION
## Summary

- InventoryImport + PersonImport E2E fixtures now run **10/10 green** against the live CashCtrl API
- Root-cause investigation uncovered three undocumented API behaviors, documented alongside the fixes
- Ships the `Async` / `Indexes` Execute params that make import actually work in production

## Fixes

**Models**
- `InventoryImportExecute` / `PersonImportExecute`: new `Async` (bool?) and `Indexes` (string?) — sync Execute path returns a masked `{"success":false,"message":"An unexpected error occurred"}`; `async=true` is required in practice.
- `InventoryImportMapping` / `PersonImportMapping`: XML doc on `Mapping` now documents the `[{from, to}]` JSON shape and that field IDs use `UPPER_SNAKE_CASE` (`NR`, `NAME_DE`, `FIRST_NAME`, …), not the camelCase used elsewhere.

**E2E tests**
- `Execute` calls now send `Async = true`.
- Use `UPPER_SNAKE_CASE` field IDs in the mapping JSON.
- Replace hardcoded `E2E-IMPORT-001` with `GenerateTestId()` per CLAUDE.md.
- Inventory scavenge now matches orphans by `Name` **or** `Nr` prefix so orphans from earlier broken-mapping runs (empty names) are caught.
- Person fixture switched from vCard to CSV — docs state mapping is not needed for vCards, so vCard sources can't exercise Mapping meaningfully.

**Diagnostic upgrade**
- `CashCtrlE2eTestBase.AssertSuccess` / `AssertCreated` now surface the API `Message` + `Errors` in the Shouldly failure output. "True expected, False got" → "API response: Message='…', Errors=[…]".

## Docs

- `doc/analysis/2026-04-19-group4-import-e2e-verification.md`: rewrote to replace the initial speculative-risks analysis with actual findings + investigation trail (curl repro, UI traffic inspection).
- `doc/analysis/2026-03-29-api-doc-discrepancies.md`: new §9 (`async=true`), §10 (Preview POST-vs-GET), §11 (`UPPER_SNAKE_CASE` in `mapping_combo`).
- `doc/analysis/2026-03-29-e2e-test-verification.md`: Group 4 row → **10/10 passed**; totals adjusted to 178 passed / ~179 remaining.

## Test plan

- [x] Build: 0 warnings, 0 errors with `TreatWarningsAsErrors=true`
- [x] Unit tests: 631 passing
- [x] Integration tests: 453 passing
- [x] E2E `InventoryImportE2eTests`: 5/5 green against live API
- [x] E2E `PersonImportE2eTests`: 5/5 green against live API

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)