### PR TITLE
fix(e2e): Group 5 Journal — items shape, write-only fields, import mappings, entry importId (#90)

### DIFF
--- a/doc/analysis/2026-03-29-api-doc-discrepancies.md
+++ b/doc/analysis/2026-03-29-api-doc-discrepancies.md
@@ -128,6 +128,37 @@ This is the **only** place in the CashCtrl API where `UPPER_SNAKE_CASE` identifi
 
 **Impact:** Inferring field IDs from model property names (e.g., `nr`, `name`, `firstName`) is wrong. Always call `mapping_combo.json` (or inspect the UI payload) to learn the correct `value` strings.
 
+### 12. Journal `items` returned as array (repeat of §4)
+
+`journal/create.json` and `journal/update.json` accept `items` as a JSON string (TEXT) for collective entries, but `journal/read.json` / `journal/list.json` return it as a parsed array (empty `[]` for regular entries). Same pattern as §4. Fix: `JsonElement?` instead of `string?`.
+
+### 13. Journal `sequenceNumberId` is write-only
+
+`journal/create.json` marks `sequenceNumberId` as mandatory, but `journal/read.json` / `journal/list.json` do not return it — the server emits the generated `reference` (e.g. `RE-2604193`) instead. A `required int` on the create model breaks deserialization across the shared hierarchy (§3 pattern). Fix: nullable `int?`, treat as required at the application level.
+
+### 14. Journal Update: echoing `items: []` back creates a broken "collective entry with 0 items"
+
+Per the update docs: *"Omit to create a regular book entry, and set if you want to create a collective book entry."* A Get→Update round-trip on a regular journal entry will echo `items: []` back, which the server interprets as a collective entry with zero items and rejects with **"At least 1 book entry must be created."** Callers must explicitly clear `items` when updating regular entries.
+
+### 15. Journal import `create.json`: `mappings` is effectively mandatory
+
+Docs don't emphasize this, but omitting `mappings` returns the masked `{"success":false,"message":"An unexpected error occurred. Please contact support."}` — no validation error hint, just a 500-style reply. The API also **silently ignores** any non-documented parameters (we had a phantom `name` field the server silently dropped).
+
+### 16. Journal import entry list / exports: `importId` query is mandatory
+
+`journal/import/entry/list.json` (and the `.xlsx` / `.csv` / `.pdf` export variants) require `importId` as a mandatory query parameter. Without it the API returns `{"success":false,"message":"ID missing."}`. The library must expose a dedicated request type (we added `JournalImportEntryListRequest : ListParams` with `required int ImportId`).
+
+### 17. Journal import entry update: undocumented mandatory fields
+
+Docs list only `id`, `amount`, `contraAccountId`, and `dateAdded` as mandatory for `journal/import/entry/update.json`. In practice the live API also rejects an update missing `debitId` / `creditId`:
+
+```
+[debitId] This field cannot be empty.
+[creditId] This field cannot be empty.
+```
+
+Callers need to echo the server-populated debit/credit IDs back on every update. Additionally, `dateAdded` in the read/list response is a CashCtrl datetime string (`2026-01-01 00:00:00.0`), but the update endpoint only accepts `YYYY-MM-DD` — so the string needs to be trimmed before sending.
+
 ## Recommendations
 
 1. **Never use `required` on properties that appear in both create requests and read responses**, unless the field name and type are identical in both directions. Use nullable properties and validate at the application level.

--- a/doc/analysis/2026-03-29-e2e-test-verification.md
+++ b/doc/analysis/2026-03-29-e2e-test-verification.md
@@ -15,12 +15,12 @@
 | 2 | Simple CRUD | Currency, CustomField, CustomFieldGroup, Rounding, SequenceNumber, TaxRate, TextTemplate, PersonTitle, Unit, 6x categories | 86 | **86/86 passed** |
 | 3 | CRUD + exports | Account, AccountBank, CostCenter, Article, FixedAsset, Person, File | 77 | **77/77 passed** |
 | 4 | Import workflows | InventoryImport, PersonImport | 10 | **10/10 passed** — see [2026-04-19 report](2026-04-19-group4-import-e2e-verification.md) |
-| 5 | Journal | Journal, JournalImport, JournalImportEntry | ~24 | **not yet run** |
+| 5 | Journal | Journal, JournalImport, JournalImportEntry | 24 | **24/24 passed** (issue #90) |
 | 6 | Order | OrderCategory, OrderLayout, Order, BookEntry, Document, OrderPayment | ~39 | **not yet run** |
 | 7 | Salary | 15 salary fixtures | ~90 | **not yet run** |
 | 8 | Meta (highest risk) | Settings, Location, FiscalPeriodTask, FiscalPeriod | ~26 | **not yet run** |
 
-**178 passed, 0 skipped, 0 failed.** ~179 tests remaining across Groups 5-8.
+**202 passed, 0 skipped, 0 failed.** ~155 tests remaining across Groups 6-8.
 
 ## What Was Fixed
 

--- a/src/CashCtrlApiNet.Abstractions/Models/Journal/Import/Entry/JournalImportEntryListRequest.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Journal/Import/Entry/JournalImportEntryListRequest.cs
@@ -1,0 +1,43 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json.Serialization;
+using CashCtrlApiNet.Abstractions.Models.Base;
+
+namespace CashCtrlApiNet.Abstractions.Models.Journal.Import.Entry;
+
+/// <summary>
+/// Journal import entry list request parameters. The <c>importId</c> query parameter is mandatory —
+/// without it the endpoint returns <c>{"success":false,"message":"ID missing."}</c>.
+/// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/journal/import/entry/list.json">API Doc</a>
+/// </summary>
+public record JournalImportEntryListRequest : ListParams
+{
+    /// <summary>
+    /// The ID of the journal import whose entries should be listed.
+    /// </summary>
+    [JsonPropertyName("importId")]
+    public required int ImportId { get; init; }
+}

--- a/src/CashCtrlApiNet.Abstractions/Models/Journal/Import/Entry/JournalImportEntryUpdate.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Journal/Import/Entry/JournalImportEntryUpdate.cs
@@ -38,4 +38,55 @@ public record JournalImportEntryUpdate : ModelBaseRecord
     /// </summary>
     [JsonPropertyName("id")]
     public required int Id { get; init; }
+
+    /// <summary>
+    /// The amount of the entry. Mandatory on update per the API; must be positive.
+    /// Nullable so the shared hierarchy still deserializes list/read responses correctly.
+    /// </summary>
+    [JsonPropertyName("amount")]
+    public double? Amount { get; init; }
+
+    /// <summary>
+    /// The date of the entry in <c>YYYY-MM-DD</c> format. Mandatory on update.
+    /// </summary>
+    [JsonPropertyName("dateAdded")]
+    public string? DateAdded { get; init; }
+
+    /// <summary>
+    /// The ID of the debit account. Required on update despite the docs listing
+    /// <c>contraAccountId</c> — the live API reports <c>debitId</c> as a mandatory field.
+    /// </summary>
+    [JsonPropertyName("debitId")]
+    public int? DebitId { get; init; }
+
+    /// <summary>
+    /// The ID of the credit account. Required on update (see note on <see cref="DebitId"/>).
+    /// </summary>
+    [JsonPropertyName("creditId")]
+    public int? CreditId { get; init; }
+
+    /// <summary>
+    /// The ID of the contra account (the opposite side of the target account). Documented as
+    /// mandatory; in practice the API also accepts <see cref="DebitId"/>/<see cref="CreditId"/>.
+    /// </summary>
+    [JsonPropertyName("contraAccountId")]
+    public int? ContraAccountId { get; init; }
+
+    /// <summary>
+    /// The title / description of the book entry.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// An optional reference / receipt for the book entry.
+    /// </summary>
+    [JsonPropertyName("reference")]
+    public string? Reference { get; init; }
+
+    /// <summary>
+    /// The ID of the tax rate.
+    /// </summary>
+    [JsonPropertyName("taxId")]
+    public int? TaxId { get; init; }
 }

--- a/src/CashCtrlApiNet.Abstractions/Models/Journal/Import/JournalImport.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Journal/Import/JournalImport.cs
@@ -40,6 +40,19 @@ public record JournalImport : JournalImportCreate
     public required int Id { get; init; }
 
     /// <summary>
+    /// A human-readable description of the import session. Populated by the server from the
+    /// source filename — not settable from the create request.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// The origin of the import session (e.g. <c>FILE</c>).
+    /// </summary>
+    [JsonPropertyName("source")]
+    public string? Source { get; init; }
+
+    /// <summary>
     /// The date and time the journal import was created.
     /// </summary>
     [JsonPropertyName("created")]

--- a/src/CashCtrlApiNet.Abstractions/Models/Journal/Import/JournalImportCreate.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Journal/Import/JournalImportCreate.cs
@@ -34,14 +34,36 @@ namespace CashCtrlApiNet.Abstractions.Models.Journal.Import;
 public record JournalImportCreate : ModelBaseRecord
 {
     /// <summary>
-    /// The ID of the file to import. Use the File API to upload a file and then use the file ID here.
+    /// The ID of the file to import. Documented as optional but in practice the create call fails
+    /// without it. Use the File API to upload a file and then use the file ID here.
     /// </summary>
     [JsonPropertyName("fileId")]
     public required int FileId { get; init; }
 
     /// <summary>
-    /// A name for the import.
+    /// Column-to-field mappings as a JSON string. Mandatory on create per the API docs, but kept
+    /// nullable because this field does not appear in the read/list responses (shared hierarchy).
+    /// Expected shape: <c>[{"columnDate":"Date","columnDescription":"Title","columnDebitName":"Debit","columnCreditName":"Credit","columnAmount":"Amount", ...}]</c>.
+    /// Each array entry also supports <c>fixed*</c> counterparts (e.g. <c>fixedDebitId</c>) instead of <c>column*</c>.
     /// </summary>
-    [JsonPropertyName("name")]
-    public string? Name { get; init; }
+    [JsonPropertyName("mappings")]
+    public string? Mappings { get; init; }
+
+    /// <summary>
+    /// Force the use of sequence numbers instead of importing the reference number from the file. Defaults to false.
+    /// </summary>
+    [JsonPropertyName("isForceSequenceNumber")]
+    public bool? IsForceSequenceNumber { get; init; }
+
+    /// <summary>
+    /// Number of lines to skip before parsing the file (useful if the header line is not the first line).
+    /// </summary>
+    [JsonPropertyName("skipRows")]
+    public int? SkipRows { get; init; }
+
+    /// <summary>
+    /// The ID of the target account (e.g. your bank account) to import the entries into.
+    /// </summary>
+    [JsonPropertyName("targetAccountId")]
+    public int? TargetAccountId { get; init; }
 }

--- a/src/CashCtrlApiNet.Abstractions/Models/Journal/JournalCreate.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Journal/JournalCreate.cs
@@ -24,6 +24,7 @@ SOFTWARE.
 */
 
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using CashCtrlApiNet.Abstractions.Models.Base;
 
@@ -48,10 +49,12 @@ public record JournalCreate : ModelBaseRecord
     public required string Title { get; init; }
 
     /// <summary>
-    /// The ID of the sequence number. See Sequence number.
+    /// The ID of the sequence number. See Sequence number. Required on create, but absent from
+    /// read/list responses (the server returns the generated <c>reference</c> instead) — so the
+    /// property is nullable to keep response deserialization working across the shared hierarchy.
     /// </summary>
     [JsonPropertyName("sequenceNumberId")]
-    public required int SequenceNumberId { get; init; }
+    public int? SequenceNumberId { get; init; }
 
     /// <summary>
     /// The ID of the debit account. See Account.
@@ -78,10 +81,12 @@ public record JournalCreate : ModelBaseRecord
     public int? TaxId { get; init; }
 
     /// <summary>
-    /// Items for collective entries. This is a JSON array with accountId, debit, and credit properties.
+    /// Items for collective entries. On create, set to a JSON array with accountId, debit, and
+    /// credit properties (CashCtrl accepts the JSON text serialized form). On read, the API returns
+    /// a parsed array — <see cref="JsonElement"/> accepts both shapes.
     /// </summary>
     [JsonPropertyName("items")]
-    public string? ItemsJson { get; init; }
+    public JsonElement? Items { get; init; }
 
     /// <summary>
     /// The ID of the cost center. See Cost center.

--- a/src/CashCtrlApiNet/Interfaces/Connectors/Journal/IJournalImportEntryService.cs
+++ b/src/CashCtrlApiNet/Interfaces/Connectors/Journal/IJournalImportEntryService.cs
@@ -44,13 +44,14 @@ public interface IJournalImportEntryService
     public Task<ApiResult<SingleResponse<JournalImportEntry>>> Get(Entry journalImportEntry, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// List journal import entries. Returns a list of journal import entries, optionally filtered and paginated.
+    /// List journal import entries. Returns a list of journal import entries for the given import,
+    /// optionally filtered and paginated. <c>importId</c> is mandatory on the underlying API.
     /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/journal/import/entry/list.json">API Doc - Journal/Import entry/List entries</a>
     /// </summary>
-    /// <param name="listParams">Optional filter and pagination parameters.</param>
+    /// <param name="request">The list request including the mandatory <c>importId</c>.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<ApiResult<ListResponse<JournalImportEntryListed>>> GetList(ListParams? listParams = null, CancellationToken cancellationToken = default);
+    public Task<ApiResult<ListResponse<JournalImportEntryListed>>> GetList(JournalImportEntryListRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update journal import entry. Updates an existing journal import entry. Returns either a success or error message.
@@ -98,26 +99,29 @@ public interface IJournalImportEntryService
     public Task<ApiResult<NoContentResponse>> Unconfirm(Entries journalImportEntries, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Export journal import entries as Excel file.
+    /// Export journal import entries as Excel file. <c>importId</c> is mandatory.
     /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/journal/import/entry/list.xlsx">API Doc - Journal/Import entry/Export Excel</a>
     /// </summary>
+    /// <param name="request">The list request including the mandatory <c>importId</c>.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<ApiResult<BinaryResponse>> ExportExcel(CancellationToken cancellationToken = default);
+    public Task<ApiResult<BinaryResponse>> ExportExcel(JournalImportEntryListRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Export journal import entries as CSV file.
+    /// Export journal import entries as CSV file. <c>importId</c> is mandatory.
     /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/journal/import/entry/list.csv">API Doc - Journal/Import entry/Export CSV</a>
     /// </summary>
+    /// <param name="request">The list request including the mandatory <c>importId</c>.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<ApiResult<BinaryResponse>> ExportCsv(CancellationToken cancellationToken = default);
+    public Task<ApiResult<BinaryResponse>> ExportCsv(JournalImportEntryListRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Export journal import entries as PDF file.
+    /// Export journal import entries as PDF file. <c>importId</c> is mandatory.
     /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/journal/import/entry/list.pdf">API Doc - Journal/Import entry/Export PDF</a>
     /// </summary>
+    /// <param name="request">The list request including the mandatory <c>importId</c>.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<ApiResult<BinaryResponse>> ExportPdf(CancellationToken cancellationToken = default);
+    public Task<ApiResult<BinaryResponse>> ExportPdf(JournalImportEntryListRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/CashCtrlApiNet/Services/Connectors/Journal/JournalImportEntryService.cs
+++ b/src/CashCtrlApiNet/Services/Connectors/Journal/JournalImportEntryService.cs
@@ -41,8 +41,8 @@ public class JournalImportEntryService(ICashCtrlConnectionHandler connectionHand
         => ConnectionHandler.GetAsync<SingleResponse<JournalImportEntry>, Entry>(Endpoint.Read, journalImportEntry, cancellationToken);
 
     /// <inheritdoc />
-    public Task<ApiResult<ListResponse<JournalImportEntryListed>>> GetList(ListParams? listParams = null, CancellationToken cancellationToken = default)
-        => ConnectionHandler.GetAsync<ListResponse<JournalImportEntryListed>>(Endpoint.List, listParams, cancellationToken);
+    public Task<ApiResult<ListResponse<JournalImportEntryListed>>> GetList(JournalImportEntryListRequest request, CancellationToken cancellationToken = default)
+        => ConnectionHandler.GetAsync<ListResponse<JournalImportEntryListed>, JournalImportEntryListRequest>(Endpoint.List, request, cancellationToken);
 
     /// <inheritdoc />
     public Task<ApiResult<NoContentResponse>> Update(JournalImportEntryUpdate journalImportEntry, CancellationToken cancellationToken = default)
@@ -65,14 +65,14 @@ public class JournalImportEntryService(ICashCtrlConnectionHandler connectionHand
         => ConnectionHandler.PostAsync<NoContentResponse, Entries>(Endpoint.Unconfirm, journalImportEntries, cancellationToken: cancellationToken);
 
     /// <inheritdoc />
-    public Task<ApiResult<BinaryResponse>> ExportExcel(CancellationToken cancellationToken = default)
-        => ConnectionHandler.GetBinaryAsync(Endpoint.ListXlsx, cancellationToken: cancellationToken);
+    public Task<ApiResult<BinaryResponse>> ExportExcel(JournalImportEntryListRequest request, CancellationToken cancellationToken = default)
+        => ConnectionHandler.GetBinaryAsync(Endpoint.ListXlsx, request, cancellationToken);
 
     /// <inheritdoc />
-    public Task<ApiResult<BinaryResponse>> ExportCsv(CancellationToken cancellationToken = default)
-        => ConnectionHandler.GetBinaryAsync(Endpoint.ListCsv, cancellationToken: cancellationToken);
+    public Task<ApiResult<BinaryResponse>> ExportCsv(JournalImportEntryListRequest request, CancellationToken cancellationToken = default)
+        => ConnectionHandler.GetBinaryAsync(Endpoint.ListCsv, request, cancellationToken);
 
     /// <inheritdoc />
-    public Task<ApiResult<BinaryResponse>> ExportPdf(CancellationToken cancellationToken = default)
-        => ConnectionHandler.GetBinaryAsync(Endpoint.ListPdf, cancellationToken: cancellationToken);
+    public Task<ApiResult<BinaryResponse>> ExportPdf(JournalImportEntryListRequest request, CancellationToken cancellationToken = default)
+        => ConnectionHandler.GetBinaryAsync(Endpoint.ListPdf, request, cancellationToken);
 }

--- a/tests/CashCtrlApiNet.E2eTests/CashCtrlE2eTestBase.cs
+++ b/tests/CashCtrlApiNet.E2eTests/CashCtrlE2eTestBase.cs
@@ -194,7 +194,7 @@ public class CashCtrlE2eTestBase
         where TData : ModelBaseRecord
     {
         result.IsHttpSuccess.ShouldBeTrue();
-        result.ResponseData.ShouldNotBeNull();
+        result.ResponseData.ShouldNotBeNull(FormatRawResponseDetails(result));
         result.ResponseData.Data.ShouldNotBeNull();
         return result.ResponseData.Data;
     }
@@ -210,9 +210,17 @@ public class CashCtrlE2eTestBase
         where TData : ModelBaseRecord
     {
         result.IsHttpSuccess.ShouldBeTrue();
-        result.ResponseData.ShouldNotBeNull();
+        result.ResponseData.ShouldNotBeNull(FormatRawResponseDetails(result));
         result.ResponseData.Data.Length.ShouldBeGreaterThan(0);
         return result.ResponseData.Data;
+    }
+
+    private static string FormatRawResponseDetails(ApiResult result)
+    {
+        var raw = result.RawResponseContent is { Length: > 0 } content
+            ? content.Length > 500 ? content[..500] + "…<truncated>" : content
+            : "<none>";
+        return $"Deserialization likely failed (ResponseData=null). Raw response body: {raw}";
     }
 
     /// <summary>

--- a/tests/CashCtrlApiNet.E2eTests/Journal/JournalE2eTests.cs
+++ b/tests/CashCtrlApiNet.E2eTests/Journal/JournalE2eTests.cs
@@ -106,7 +106,9 @@ public class JournalE2eTests : CashCtrlE2eTestBase
         res.CashCtrlHttpStatusCodeDescription.ShouldNotBeNullOrEmpty();
 
         journal.Title.ShouldBe(_testId);
-        journal.SequenceNumberId.ShouldBe(_sequenceNumberId);
+        // SequenceNumberId does not round-trip — the server returns the generated Reference
+        // (e.g. "RE-2604193") in its place. Assert on the derived Reference instead.
+        journal.Reference.ShouldNotBeNullOrEmpty();
     }
 
     /// <summary>
@@ -154,7 +156,11 @@ public class JournalE2eTests : CashCtrlE2eTestBase
         var updatedTitle = $"{_testId}-Updated";
         var res = await CashCtrlApiClient.Journal.Journal.Update((journal as JournalUpdate) with
         {
-            Title = updatedTitle
+            Title = updatedTitle,
+            // Per API docs: items must be OMITTED for a regular (debit/credit) entry.
+            // The read response returns items as [] which, if echoed back, is interpreted as
+            // "collective entry with zero items" → "At least 1 book entry must be created".
+            Items = null
         });
         AssertSuccess(res);
 

--- a/tests/CashCtrlApiNet.E2eTests/Journal/JournalImportE2eTests.cs
+++ b/tests/CashCtrlApiNet.E2eTests/Journal/JournalImportE2eTests.cs
@@ -56,14 +56,21 @@ public class JournalImportE2eTests : CashCtrlE2eTestBase
         // Upload a CSV file for import via File.Prepare + File.Persist
         var fileId = await UploadImportFile(_testId);
 
-        // Create primary test journal import
+        // Create primary test journal import. The mappings JSON is mandatory per API docs —
+        // without it the server returns a masked "unexpected error".
         var createResult = await CashCtrlApiClient.Journal.Import.Create(new()
         {
             FileId = fileId,
-            Name = _testId
+            Mappings = JournalImportMappings
         });
         _setupImportId = AssertCreated(createResult);
     }
+
+    /// <summary>
+    /// JSON mappings matching the CSV columns produced by <see cref="UploadImportFile"/>.
+    /// </summary>
+    private const string JournalImportMappings =
+        """[{"columnDate":"Date","columnDescription":"Title","columnDebitName":"Debit","columnCreditName":"Credit","columnAmount":"Amount"}]""";
 
     /// <summary>
     /// Cleans up all test data created during the fixture
@@ -84,7 +91,9 @@ public class JournalImportE2eTests : CashCtrlE2eTestBase
         res.RequestsLeft.Value.ShouldBeGreaterThan(0);
         res.CashCtrlHttpStatusCodeDescription.ShouldNotBeNullOrEmpty();
 
-        import.Name.ShouldBe(_testId);
+        // The server derives Description from the uploaded filename, so it contains our test id.
+        import.Description.ShouldNotBeNullOrEmpty();
+        import.Description!.ShouldContain(_testId);
     }
 
     /// <summary>
@@ -111,7 +120,7 @@ public class JournalImportE2eTests : CashCtrlE2eTestBase
         var res = await CashCtrlApiClient.Journal.Import.Create(new()
         {
             FileId = fileId,
-            Name = GenerateTestId()
+            Mappings = JournalImportMappings
         });
         AssertCreated(res);
     }

--- a/tests/CashCtrlApiNet.E2eTests/Journal/JournalImportEntryE2eTests.cs
+++ b/tests/CashCtrlApiNet.E2eTests/Journal/JournalImportEntryE2eTests.cs
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+using CashCtrlApiNet.Abstractions.Models.Journal.Import.Entry;
 using Shouldly;
 
 namespace CashCtrlApiNet.E2eTests.Journal;
@@ -36,7 +37,9 @@ namespace CashCtrlApiNet.E2eTests.Journal;
 public class JournalImportEntryE2eTests : CashCtrlE2eTestBase
 {
     private string _testId = null!;
+    private int _setupImportId;
     private int _setupImportEntryId;
+    private JournalImportEntryListRequest ListRequest => new() { ImportId = _setupImportId };
 
     /// <summary>
     /// Scavenges orphan test data and creates the prerequisite journal import with entries for the fixture
@@ -56,16 +59,17 @@ public class JournalImportEntryE2eTests : CashCtrlE2eTestBase
         // Upload a CSV file for import via File.Prepare + File.Persist
         var fileId = await UploadImportFile(_testId);
 
-        // Create a journal import (prerequisite for import entries)
+        // Create a journal import (prerequisite for import entries). Mappings JSON is mandatory
+        // per API docs — without it the server returns a masked "unexpected error".
         var importResult = await CashCtrlApiClient.Journal.Import.Create(new()
         {
             FileId = fileId,
-            Name = _testId
+            Mappings = """[{"columnDate":"Date","columnDescription":"Title","columnDebitName":"Debit","columnCreditName":"Credit","columnAmount":"Amount"}]"""
         });
-        AssertCreated(importResult);
+        _setupImportId = AssertCreated(importResult);
 
         // Discover the first import entry created by the import
-        var entryListResult = await CashCtrlApiClient.Journal.ImportEntry.GetList();
+        var entryListResult = await CashCtrlApiClient.Journal.ImportEntry.GetList(ListRequest);
         var entries = entryListResult.ResponseData?.Data;
         entries.ShouldNotBeNull("Import should have produced entries");
         entries.Value.Length.ShouldBeGreaterThan(0, "Import should have at least one entry");
@@ -100,7 +104,7 @@ public class JournalImportEntryE2eTests : CashCtrlE2eTestBase
     [Test, Order(2)]
     public async Task GetList_Success()
     {
-        var res = await CashCtrlApiClient.Journal.ImportEntry.GetList();
+        var res = await CashCtrlApiClient.Journal.ImportEntry.GetList(ListRequest);
         var entries = AssertSuccess(res);
 
         entries.Length.ShouldBe(res.ResponseData!.Total);
@@ -113,9 +117,19 @@ public class JournalImportEntryE2eTests : CashCtrlE2eTestBase
     [Test, Order(3)]
     public async Task Update_Success()
     {
-        var res = await CashCtrlApiClient.Journal.ImportEntry.Update(new()
+        // Read the entry first so we can echo back the server-populated debit/credit IDs.
+        // The API requires amount, dateAdded, debitId and creditId on update even though the
+        // docs only mark contraAccountId as mandatory — the live API reports all four as
+        // "cannot be empty" when they're omitted.
+        var get = await CashCtrlApiClient.Journal.ImportEntry.Get(new() { Id = _setupImportEntryId });
+        var entry = AssertSuccess(get);
+
+        var res = await CashCtrlApiClient.Journal.ImportEntry.Update((entry as JournalImportEntryUpdate) with
         {
-            Id = _setupImportEntryId
+            Title = $"{_testId}-Updated",
+            // The response DateAdded is a CashCtrl datetime string ("2026-01-01 00:00:00.0").
+            // The update endpoint only accepts YYYY-MM-DD, so trim to the date portion.
+            DateAdded = entry.DateAdded?.Split(' ')[0]
         });
         AssertSuccess(res);
     }
@@ -166,7 +180,7 @@ public class JournalImportEntryE2eTests : CashCtrlE2eTestBase
     [Test, Order(8)]
     public async Task ExportExcel_Success()
     {
-        var export = AssertSuccess(await CashCtrlApiClient.Journal.ImportEntry.ExportExcel());
+        var export = AssertSuccess(await CashCtrlApiClient.Journal.ImportEntry.ExportExcel(ListRequest));
         await DownloadFile(export.FileName!, export.Data);
     }
 
@@ -176,7 +190,7 @@ public class JournalImportEntryE2eTests : CashCtrlE2eTestBase
     [Test, Order(9)]
     public async Task ExportCsv_Success()
     {
-        var export = AssertSuccess(await CashCtrlApiClient.Journal.ImportEntry.ExportCsv());
+        var export = AssertSuccess(await CashCtrlApiClient.Journal.ImportEntry.ExportCsv(ListRequest));
         await DownloadFile(export.FileName!, export.Data);
     }
 
@@ -186,7 +200,7 @@ public class JournalImportEntryE2eTests : CashCtrlE2eTestBase
     [Test, Order(10)]
     public async Task ExportPdf_Success()
     {
-        var export = AssertSuccess(await CashCtrlApiClient.Journal.ImportEntry.ExportPdf());
+        var export = AssertSuccess(await CashCtrlApiClient.Journal.ImportEntry.ExportPdf(ListRequest));
         await DownloadFile(export.FileName!, export.Data);
     }
 

--- a/tests/CashCtrlApiNet.IntegrationTests/Fakers/JournalFakers.cs
+++ b/tests/CashCtrlApiNet.IntegrationTests/Fakers/JournalFakers.cs
@@ -111,7 +111,7 @@ public static class JournalFakers
         {
             Id = f.Random.Int(1, 9999),
             FileId = f.Random.Int(1, 9999),
-            Name = f.Lorem.Word(),
+            Description = f.Lorem.Word(),
             CreatedBy = f.Person.UserName,
             LastUpdatedBy = f.Person.UserName
         });
@@ -123,7 +123,7 @@ public static class JournalFakers
         .CustomInstantiator(f => new()
         {
             FileId = f.Random.Int(1, 9999),
-            Name = f.Lorem.Word()
+            Mappings = """[{"columnAmount":"Amount","columnDate":"Date"}]"""
         });
 
     /// <summary>

--- a/tests/CashCtrlApiNet.IntegrationTests/Journal/JournalImportEntryServiceIntegrationTests.cs
+++ b/tests/CashCtrlApiNet.IntegrationTests/Journal/JournalImportEntryServiceIntegrationTests.cs
@@ -67,7 +67,7 @@ public class JournalImportEntryServiceIntegrationTests : IntegrationTestBase
             CashCtrlResponseFactory.ListResponse(entries));
 
         // Act
-        var result = await Client.Journal.ImportEntry.GetList();
+        var result = await Client.Journal.ImportEntry.GetList(new() { ImportId = 1 });
 
         // Assert
         result.IsHttpSuccess.ShouldBeTrue();
@@ -188,7 +188,7 @@ public class JournalImportEntryServiceIntegrationTests : IntegrationTestBase
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "import-entries.xlsx");
 
         // Act
-        var result = await Client.Journal.ImportEntry.ExportExcel();
+        var result = await Client.Journal.ImportEntry.ExportExcel(new() { ImportId = 1 });
 
         // Assert
         result.IsHttpSuccess.ShouldBeTrue();
@@ -207,7 +207,7 @@ public class JournalImportEntryServiceIntegrationTests : IntegrationTestBase
         Server.StubGetBinary("/api/v1/journal/import/entry/list.csv", csvBytes, "text/csv", "import-entries.csv");
 
         // Act
-        var result = await Client.Journal.ImportEntry.ExportCsv();
+        var result = await Client.Journal.ImportEntry.ExportCsv(new() { ImportId = 1 });
 
         // Assert
         result.IsHttpSuccess.ShouldBeTrue();
@@ -226,7 +226,7 @@ public class JournalImportEntryServiceIntegrationTests : IntegrationTestBase
         Server.StubGetBinary("/api/v1/journal/import/entry/list.pdf", pdfBytes, "application/pdf", "import-entries.pdf");
 
         // Act
-        var result = await Client.Journal.ImportEntry.ExportPdf();
+        var result = await Client.Journal.ImportEntry.ExportPdf(new() { ImportId = 1 });
 
         // Assert
         result.IsHttpSuccess.ShouldBeTrue();

--- a/tests/CashCtrlApiNet.IntegrationTests/Journal/JournalImportServiceIntegrationTests.cs
+++ b/tests/CashCtrlApiNet.IntegrationTests/Journal/JournalImportServiceIntegrationTests.cs
@@ -55,7 +55,7 @@ public class JournalImportServiceIntegrationTests : IntegrationTestBase
         result.ResponseData.Data.ShouldNotBeNull();
         result.ResponseData.Data.Id.ShouldBe(import.Id);
         result.ResponseData.Data.FileId.ShouldBe(import.FileId);
-        result.ResponseData.Data.Name.ShouldBe(import.Name);
+        result.ResponseData.Data.Description.ShouldBe(import.Description);
     }
 
     /// <summary>

--- a/tests/CashCtrlApiNet.UnitTests/Journal/JournalImportEntryServiceTests.cs
+++ b/tests/CashCtrlApiNet.UnitTests/Journal/JournalImportEntryServiceTests.cs
@@ -61,42 +61,46 @@ public class JournalImportEntryServiceTests : ServiceTestBase<JournalImportEntry
     [Test]
     public async Task GetList_ShouldCallCorrectEndpoint()
     {
+        var request = new JournalImportEntryListRequest { ImportId = 7 };
         ConnectionHandler
-            .GetAsync<ListResponse<JournalImportEntryListed>>(Arg.Any<string>(), Arg.Any<ListParams?>(), Arg.Any<CancellationToken>())
+            .GetAsync<ListResponse<JournalImportEntryListed>, JournalImportEntryListRequest>(
+                Arg.Any<string>(), Arg.Any<JournalImportEntryListRequest>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<ListResponse<JournalImportEntryListed>>());
 
-        await Service.GetList();
+        await Service.GetList(request);
 
         await ConnectionHandler.Received(1)
-            .GetAsync<ListResponse<JournalImportEntryListed>>(
-                JournalEndpoints.ImportEntry.List, (ListParams?)null, Arg.Any<CancellationToken>());
+            .GetAsync<ListResponse<JournalImportEntryListed>, JournalImportEntryListRequest>(
+                JournalEndpoints.ImportEntry.List, request, Arg.Any<CancellationToken>());
     }
 
     [Test]
-    public async Task GetList_WithListParams_ShouldCallCorrectEndpoint()
+    public async Task GetList_WithFilter_ShouldCallCorrectEndpoint()
     {
-        var listParams = new ListParams { Query = "test", OnlyActive = true };
+        var request = new JournalImportEntryListRequest { ImportId = 7, Query = "test", OnlyActive = true };
         ConnectionHandler
-            .GetAsync<ListResponse<JournalImportEntryListed>>(Arg.Any<string>(), Arg.Any<ListParams?>(), Arg.Any<CancellationToken>())
+            .GetAsync<ListResponse<JournalImportEntryListed>, JournalImportEntryListRequest>(
+                Arg.Any<string>(), Arg.Any<JournalImportEntryListRequest>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<ListResponse<JournalImportEntryListed>>());
 
-        await Service.GetList(listParams);
+        await Service.GetList(request);
 
         await ConnectionHandler.Received(1)
-            .GetAsync<ListResponse<JournalImportEntryListed>>(
-                JournalEndpoints.ImportEntry.List, listParams, Arg.Any<CancellationToken>());
+            .GetAsync<ListResponse<JournalImportEntryListed>, JournalImportEntryListRequest>(
+                JournalEndpoints.ImportEntry.List, request, Arg.Any<CancellationToken>());
     }
 
     [Test]
-    public async Task GetList_WithListParams_ShouldReturnResult()
+    public async Task GetList_WithFilter_ShouldReturnResult()
     {
-        var listParams = new ListParams { Query = "test" };
+        var request = new JournalImportEntryListRequest { ImportId = 7, Query = "test" };
         var expected = new ApiResult<ListResponse<JournalImportEntryListed>>();
         ConnectionHandler
-            .GetAsync<ListResponse<JournalImportEntryListed>>(Arg.Any<string>(), Arg.Any<ListParams?>(), Arg.Any<CancellationToken>())
+            .GetAsync<ListResponse<JournalImportEntryListed>, JournalImportEntryListRequest>(
+                Arg.Any<string>(), Arg.Any<JournalImportEntryListRequest>(), Arg.Any<CancellationToken>())
             .Returns(expected);
 
-        var result = await Service.GetList(listParams);
+        var result = await Service.GetList(request);
 
         result.ShouldBe(expected);
     }
@@ -179,42 +183,45 @@ public class JournalImportEntryServiceTests : ServiceTestBase<JournalImportEntry
     [Test]
     public async Task ExportExcel_ShouldCallGetBinaryAsync()
     {
+        var request = new JournalImportEntryListRequest { ImportId = 7 };
         ConnectionHandler
-            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<JournalImportEntryListRequest>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<BinaryResponse> { ResponseData = new() { Data = [1, 2, 3] } });
 
-        var result = await Service.ExportExcel();
+        var result = await Service.ExportExcel(request);
 
         await ConnectionHandler.Received(1)
-            .GetBinaryAsync(JournalEndpoints.ImportEntry.ListXlsx, Arg.Any<CancellationToken>());
+            .GetBinaryAsync(JournalEndpoints.ImportEntry.ListXlsx, request, Arg.Any<CancellationToken>());
         result.ShouldNotBeNull();
     }
 
     [Test]
     public async Task ExportCsv_ShouldCallGetBinaryAsync()
     {
+        var request = new JournalImportEntryListRequest { ImportId = 7 };
         ConnectionHandler
-            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<JournalImportEntryListRequest>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<BinaryResponse> { ResponseData = new() { Data = [1, 2, 3] } });
 
-        var result = await Service.ExportCsv();
+        var result = await Service.ExportCsv(request);
 
         await ConnectionHandler.Received(1)
-            .GetBinaryAsync(JournalEndpoints.ImportEntry.ListCsv, Arg.Any<CancellationToken>());
+            .GetBinaryAsync(JournalEndpoints.ImportEntry.ListCsv, request, Arg.Any<CancellationToken>());
         result.ShouldNotBeNull();
     }
 
     [Test]
     public async Task ExportPdf_ShouldCallGetBinaryAsync()
     {
+        var request = new JournalImportEntryListRequest { ImportId = 7 };
         ConnectionHandler
-            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<JournalImportEntryListRequest>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<BinaryResponse> { ResponseData = new() { Data = [1, 2, 3] } });
 
-        var result = await Service.ExportPdf();
+        var result = await Service.ExportPdf(request);
 
         await ConnectionHandler.Received(1)
-            .GetBinaryAsync(JournalEndpoints.ImportEntry.ListPdf, Arg.Any<CancellationToken>());
+            .GetBinaryAsync(JournalEndpoints.ImportEntry.ListPdf, request, Arg.Any<CancellationToken>());
         result.ShouldNotBeNull();
     }
 }


### PR DESCRIPTION
## Summary

- `JournalE2eTests`, `JournalImportE2eTests`, `JournalImportEntryE2eTests` all run **24/24 green** against the live CashCtrl API
- Six undocumented API behaviors fixed and documented (`async=true`-style gaps, write-only fields, mandatory query params not marked as such)
- New typed request `JournalImportEntryListRequest` for the entry list + export endpoints that require `importId`

## Model + service changes

**Write-side**
- `JournalCreate.ItemsJson` (string?) → `Items` (JsonElement?) — API returns a parsed array on read
- `JournalCreate.SequenceNumberId`: `required int` → `int?` — write-only; absent from read/list responses
- `JournalImportCreate`: removed phantom `Name`; added mandatory `Mappings` (JSON), plus optional `IsForceSequenceNumber`, `SkipRows`, `TargetAccountId`
- `JournalImportEntryUpdate`: expanded from Id-only to include `Amount`, `DateAdded`, `DebitId`, `CreditId`, `ContraAccountId`, `Title`, `Reference`, `TaxId` (API rejects updates without debit/credit even though docs only list `contraAccountId`)
- New `JournalImportEntryListRequest : ListParams` with `required int ImportId`

**Read-side**
- `JournalImport`: added `Description` (server-populated from filename) and `Source`

**Service API**
- `IJournalImportEntryService.GetList` / `ExportExcel` / `ExportCsv` / `ExportPdf` now take a typed `JournalImportEntryListRequest` — the underlying API rejects these without `importId` (`{"success":false,"message":"ID missing."}`).

## Tests
- `JournalE2eTests.Get_Success`: asserts on `Reference` (the round-trippable field), not `SequenceNumberId`.
- `JournalE2eTests.Update_Success`: explicitly clears `Items = null` when spreading from a read — otherwise `items: []` is interpreted as a collective entry with 0 items.
- `JournalImportE2eTests`: Create now sends the mandatory `mappings` JSON; asserts on `Description`.
- `JournalImportEntryE2eTests.Update_Success`: Get first, echo `DebitId`/`CreditId`, trim datetime→date for `DateAdded`.

## Diagnostic upgrade
- `CashCtrlE2eTestBase.AssertSuccess<TData>()` for `SingleResponse<TData>` and `ListResponse<TData>` now surfaces `RawResponseContent` in the Shouldly failure message when `ResponseData` is null — deserialization failures no longer require a second round-trip to diagnose.

## Docs
- `doc/analysis/2026-03-29-api-doc-discrepancies.md`: added §§12–17 covering the new findings
- `doc/analysis/2026-03-29-e2e-test-verification.md`: Group 5 row → **24/24 passed**; totals 202 passed / ~155 remaining

## Test plan

- [x] Build: 0 warnings, 0 errors with `TreatWarningsAsErrors=true`
- [x] Unit tests: 631 passing
- [x] Integration tests: 453 passing
- [x] E2E `JournalE2eTests`: 10/10 green
- [x] E2E `JournalImportE2eTests`: 4/4 green
- [x] E2E `JournalImportEntryE2eTests`: 10/10 green

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)