### PR TITLE
test: align OrderCategoryServiceTests.GetStatus mock with SingleResponse&lt;OrderCategoryStatus&gt;

### DIFF
--- a/tests/CashCtrlApiNet.UnitTests/Order/OrderCategoryServiceTests.cs
+++ b/tests/CashCtrlApiNet.UnitTests/Order/OrderCategoryServiceTests.cs
@@ -177,14 +177,14 @@ public class OrderCategoryServiceTests : ServiceTestBase<OrderCategoryService>
     {
         var entry = new Entry { Id = 42 };
         ConnectionHandler
-            .GetAsync<SingleResponse<OrderCategory>, Entry>(
+            .GetAsync<SingleResponse<OrderCategoryStatus>, Entry>(
                 Arg.Any<string>(), Arg.Any<Entry>(), Arg.Any<CancellationToken>())
-            .Returns(new ApiResult<SingleResponse<OrderCategory>>());
+            .Returns(new ApiResult<SingleResponse<OrderCategoryStatus>>());
 
         await Service.GetStatus(entry);
 
         await ConnectionHandler.Received(1)
-            .GetAsync<SingleResponse<OrderCategory>, Entry>(
+            .GetAsync<SingleResponse<OrderCategoryStatus>, Entry>(
                 OrderEndpoints.Category.ReadStatus, entry, Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Summary

Missed unit test in PR #120 when `IOrderCategoryService.GetStatus` was retyped from `SingleResponse<OrderCategory>` to `SingleResponse<OrderCategoryStatus>` (the `/order/category/read_status.json` endpoint returns a status row, not a category — see §21 in the discrepancies doc).

The test's `NSubstitute.Received(1)` expectation still referenced the old type, so the mock matched nothing and the call-verification failed with:

```
Expected to receive exactly 1 call matching:
    GetAsync<SingleResponse<OrderCategory>, Entry>(…)
Actually received no matching calls.
```

## Fix

One-line type swap — test now matches the real service signature. Locally: `9/9 OrderCategoryServiceTests passed`.

## Test plan

- [x] `dotnet test tests/CashCtrlApiNet.UnitTests` with filter `OrderCategoryServiceTests` — 9/9 green
- [x] Build clean with `TreatWarningsAsErrors=true`

Relates to #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)