### PR TITLE
fix(report): align ReportElement/ReportSet models with live API

### DIFF
--- a/doc/analysis/2026-03-29-api-doc-discrepancies.md
+++ b/doc/analysis/2026-03-29-api-doc-discrepancies.md
@@ -231,6 +231,55 @@ Additionally, payment validation requires a fully-provisioned business context (
 
 The `OrderPaymentRequest` model matches the API spec exactly; the Create/Download E2E tests in `OrderPaymentE2eTests` are marked `[Ignore]` pending a dedicated fixture that provisions a Location + a Person with addresses.
 
+### 28. Report domain: "report set" vs "report collection" naming drift, and element-scope IDs
+
+The CashCtrl UI / docs use both "report set" and "report collection" to refer to the same entity. The actual API paths live under `/api/v1/report/collection/*` and the parameter name is consistently `collectionId`, not `reportSetId` or `reportId`. Every endpoint that takes a report set as input uses `collectionId`:
+
+- `report/collection/meta.json`, `download.pdf`, `download.csv`, `download.xlsx`, `download_annualreport.pdf` → `collectionId` (not `id`)
+- `report/element/create.json`, `update.json` → `collectionId` is the parent scope field (*not* `reportId` or `setId`)
+- `report/element/reorder.json` → **requires** `collectionId` (undocumented — see below)
+
+Meanwhile the element-side endpoints use *yet another* ID parameter:
+
+- `report/element/read.json` → `id`
+- `report/element/data.json`, `data.html`, `meta.json`, `download.pdf`, `download.csv`, `download.xlsx` → `elementId`
+
+Three different names (`id`, `elementId`, `collectionId`) for what's logically "the element's ID" / "the collection's ID" across sibling endpoints on the same entity.
+
+### 29. `report/element/create.json`: `type` is required despite being documented as optional
+
+Omitting `type` causes the API to reject with `[type] Invalid value.` — the docs list `type` as a plain parameter with no required flag. `type` is an enum (`JOURNAL`, `BALANCE`, `PLS`, `STAGGERED`, `COST_CENTER_PLS`, `COST_CENTER_BALANCE`, `CHART_OF_ACCOUNTS`, `OPEN_DEBTORS`, … ~40 values) modeled as `ReportElementType`.
+
+Related: `accountId` is documented as required but is only required for element types with a primary account dimension. `ChartOfAccounts`, for example, treats the whole chart as its dataset and silently stores `accountId=null` on create.
+
+### 30. Report meta endpoints return a slim document-header shape — not the entity shape
+
+`report/element/meta.json` and `report/collection/meta.json` don't return the `ReportElement` / `ReportSet` shape — they return a compact "document header" projection used when rendering the report:
+
+| Endpoint | Response fields |
+|----------|-----------------|
+| `report/element/meta.json` | `title`, `text`, `periodLabel`, `isHideTitle`, `isBeta`, `isPro` |
+| `report/collection/meta.json` | `title`, `text`, `periodLabel`, `logoUrl`, `logoHeight` |
+
+Neither payload has an `id` field — the response is keyed by the request's `elementId`/`collectionId`. The library therefore has dedicated `ReportElementMeta` and `ReportCollectionMeta` records distinct from `ReportElement`/`ReportSet`.
+
+### 31. `report/element/data.json` response shape varies by report type
+
+The data endpoint returns JSON whose structure depends entirely on the element's `type`. `ChartOfAccounts` returns a recursive tree of account nodes; `Journal` returns a flat list of entries; `Balance`/`Pls` return grouped sections; etc. There is no common envelope beyond `{"success": true, "data": …}`.
+
+The library therefore exposes `IReportElementService.GetData` as `Task<ApiResult>` (untyped) and carries the raw JSON on `ApiResult.RawResponseContent`. Callers parse into the shape appropriate for their report type. The untyped `GetAsync` overloads on `ICashCtrlConnectionHandler` were updated to always populate `RawResponseContent` (previously only populated on deserialization failure).
+
+### 32. `report/element/reorder.json`: `collectionId` is required but undocumented
+
+Reordering elements without `collectionId` fails with `ID missing.` — the API needs the parent scope to know *which* collection's element order is being changed. The docs list only `ids`, `target`, `before`.
+
+This follows the same pattern as `customfield/reorder.json` / `customfield/group/reorder.json` requiring an undocumented `type` scope field (§6). Generalizes to: **reorder endpoints on child entities require the parent-scope ID.**
+
+### 33. Report element read/export edge cases
+
+- **`negateAmount` is silently discarded on read for certain element types.** `ChartOfAccounts` accepts `negateAmount` on create/update but never reflects it back in `read.json`. The flag is only meaningful for report types with a primary amount dimension. Don't round-trip-verify this field in tests against `ChartOfAccounts` elements.
+- **`data.html` serves the body inline with no `Content-Disposition` header.** Unlike the PDF/CSV/Excel downloads, the HTML endpoint's response carries no filename. `BinaryResponse.FileName` will be `null` — callers must synthesize a filename if saving locally.
+
 ## Recommendations
 
 1. **Never use `required` on properties that appear in both create requests and read responses**, unless the field name and type are identical in both directions. Use nullable properties and validate at the application level.

--- a/doc/analysis/2026-03-29-e2e-test-verification.md
+++ b/doc/analysis/2026-03-29-e2e-test-verification.md
@@ -12,6 +12,7 @@
 | Group | Scope | Fixtures | Tests | Status |
 |-------|-------|----------|-------|--------|
 | 1 | Read-only | Report, Organization, History, SalaryField | 5 | **5/5 passed** |
+| 1a | Report element/set (extended after initial Group 1) | ReportSet, ReportElement | 21 | **21/21 passed 2026-04-19** (issue [#123](https://github.com/AMANDA-Technology/CashCtrlApiNet/issues/123) follow-up) |
 | 2 | Simple CRUD | Currency, CustomField, CustomFieldGroup, Rounding, SequenceNumber, TaxRate, TextTemplate, PersonTitle, Unit, 6x categories | 86 | **86/86 passed** |
 | 3 | CRUD + exports | Account, AccountBank, CostCenter, Article, FixedAsset, Person, File | 77 | **77/77 passed** |
 | 4 | Import workflows | InventoryImport, PersonImport | 10 | **10/10 passed** — see [2026-04-19 report](2026-04-19-group4-import-e2e-verification.md) |
@@ -20,7 +21,7 @@
 | 7 | Salary | 15 salary fixtures | ~90 | **not yet run** |
 | 8 | Meta (highest risk) | Settings, Location, FiscalPeriodTask, FiscalPeriod | ~26 | **not yet run** |
 
-**241 passed, 2 skipped, 0 failed.** ~116 tests remaining across Groups 7-8. The 2 skipped tests are `OrderPaymentE2eTests.Create_Success` and `Download_Success`, blocked on `Location` provisioning + `Person.Addresses` model support — tracked as a follow-up to #91.
+**262 passed, 2 skipped, 0 failed.** ~116 tests remaining across Groups 7-8. The 2 skipped tests are `OrderPaymentE2eTests.Create_Success` and `Download_Success`, blocked on `Location` provisioning + `Person.Addresses` model support — tracked as a follow-up to #91.
 
 ## What Was Fixed
 
@@ -89,6 +90,7 @@ Also renamed `BalanceResponse` to `DecimalResponse` (with `.Value` instead of `.
 | `SalaryFieldE2eTests` | `Name` assertion on field that uses a different property |
 | `OrganizationE2eTests` | Logo endpoint has no `Content-Disposition` header |
 | `ReportElementE2eTests` | Used tree node ID instead of report set ID |
+| `ReportSetE2eTests`, `ReportElementE2eTests` (2026-04-19) | Rewrote models + tests for `collectionId` scope, `ReportElementType` enum, dedicated `ReportElementMeta`/`ReportCollectionMeta` shapes, untyped `GetData`, reorder `collectionId` requirement — see discrepancies §§28-33 |
 | All file upload tests (5 files) | Rewrote to use 3-step workflow (Prepare metadata + PUT binary + Persist) |
 
 ## Remaining Work for Groups 4-8

--- a/src/CashCtrlApiNet.Abstractions/Enums/Report/ReportElementType.cs
+++ b/src/CashCtrlApiNet.Abstractions/Enums/Report/ReportElementType.cs
@@ -1,0 +1,153 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json.Serialization;
+
+namespace CashCtrlApiNet.Abstractions.Enums.Report;
+
+/// <summary>
+/// The type of report rendered by a <c>ReportElement</c>. Mandatory on
+/// <c>/report/element/create.json</c>. <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/element/create.json">API Doc</a>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<ReportElementType>))]
+public enum ReportElementType
+{
+    /// <summary>Journal entries list.</summary>
+    [JsonStringEnumMemberName("JOURNAL")] Journal,
+
+    /// <summary>Balance sheet.</summary>
+    [JsonStringEnumMemberName("BALANCE")] Balance,
+
+    /// <summary>Profit and loss statement.</summary>
+    [JsonStringEnumMemberName("PLS")] Pls,
+
+    /// <summary>Staggered P&amp;L / balance report.</summary>
+    [JsonStringEnumMemberName("STAGGERED")] Staggered,
+
+    /// <summary>Cost center profit and loss statement.</summary>
+    [JsonStringEnumMemberName("COST_CENTER_PLS")] CostCenterPls,
+
+    /// <summary>Cost center balance.</summary>
+    [JsonStringEnumMemberName("COST_CENTER_BALANCE")] CostCenterBalance,
+
+    /// <summary>Cost center allocation.</summary>
+    [JsonStringEnumMemberName("COST_CENTER_ALLOCATION")] CostCenterAllocation,
+
+    /// <summary>Cost center target vs. actual.</summary>
+    [JsonStringEnumMemberName("COST_CENTER_TARGET")] CostCenterTarget,
+
+    /// <summary>Cost center statements.</summary>
+    [JsonStringEnumMemberName("COST_CENTER_STATEMENTS")] CostCenterStatements,
+
+    /// <summary>Chart of accounts.</summary>
+    [JsonStringEnumMemberName("CHART_OF_ACCOUNTS")] ChartOfAccounts,
+
+    /// <summary>Open debtors (receivables) list.</summary>
+    [JsonStringEnumMemberName("OPEN_DEBTORS")] OpenDebtors,
+
+    /// <summary>Open creditors (payables) list.</summary>
+    [JsonStringEnumMemberName("OPEN_CREDITORS")] OpenCreditors,
+
+    /// <summary>People list.</summary>
+    [JsonStringEnumMemberName("PEOPLE")] People,
+
+    /// <summary>Organizational chart.</summary>
+    [JsonStringEnumMemberName("ORG_CHART")] OrgChart,
+
+    /// <summary>Sales tax statement.</summary>
+    [JsonStringEnumMemberName("SALES_TAX")] SalesTax,
+
+    /// <summary>Target (budget) comparison.</summary>
+    [JsonStringEnumMemberName("TARGET")] Target,
+
+    /// <summary>Result by article per person.</summary>
+    [JsonStringEnumMemberName("RESULT_BY_ARTICLE_PER_PERSON")] ResultByArticlePerPerson,
+
+    /// <summary>Expense by person.</summary>
+    [JsonStringEnumMemberName("EXPENSE_BY_PERSON")] ExpenseByPerson,
+
+    /// <summary>Revenue by person.</summary>
+    [JsonStringEnumMemberName("REVENUE_BY_PERSON")] RevenueByPerson,
+
+    /// <summary>Revenue by responsible person.</summary>
+    [JsonStringEnumMemberName("REVENUE_BY_RESPONSIBLE_PERSON")] RevenueByResponsiblePerson,
+
+    /// <summary>Result by article.</summary>
+    [JsonStringEnumMemberName("RESULT_BY_ARTICLE")] ResultByArticle,
+
+    /// <summary>Statements list.</summary>
+    [JsonStringEnumMemberName("STATEMENTS")] Statements,
+
+    /// <summary>Balance list.</summary>
+    [JsonStringEnumMemberName("BALANCE_LIST")] BalanceList,
+
+    /// <summary>Key figures.</summary>
+    [JsonStringEnumMemberName("KEY_FIGURES")] KeyFigures,
+
+    /// <summary>Expense by person chart.</summary>
+    [JsonStringEnumMemberName("EXPENSE_BY_PERSON_CHART")] ExpenseByPersonChart,
+
+    /// <summary>Revenue by person chart.</summary>
+    [JsonStringEnumMemberName("REVENUE_BY_PERSON_CHART")] RevenueByPersonChart,
+
+    /// <summary>Result by article chart.</summary>
+    [JsonStringEnumMemberName("RESULT_BY_ARTICLE_CHART")] ResultByArticleChart,
+
+    /// <summary>Balance progression chart.</summary>
+    [JsonStringEnumMemberName("BALANCE_PROG_CHART")] BalanceProgChart,
+
+    /// <summary>Balance share chart.</summary>
+    [JsonStringEnumMemberName("BALANCE_SHARE_CHART")] BalanceShareChart,
+
+    /// <summary>Salary book entries.</summary>
+    [JsonStringEnumMemberName("SALARY_BOOK_ENTRIES")] SalaryBookEntries,
+
+    /// <summary>Salary list.</summary>
+    [JsonStringEnumMemberName("SALARY_LIST")] SalaryList,
+
+    /// <summary>Salary types.</summary>
+    [JsonStringEnumMemberName("SALARY_TYPES")] SalaryTypes,
+
+    /// <summary>Salary type recap.</summary>
+    [JsonStringEnumMemberName("SALARY_TYPE_RECAP")] SalaryTypeRecap,
+
+    /// <summary>Salary configuration.</summary>
+    [JsonStringEnumMemberName("SALARY_CONFIGURATION")] SalaryConfiguration,
+
+    /// <summary>Social insurance settlement.</summary>
+    [JsonStringEnumMemberName("SETTLEMENT")] Settlement,
+
+    /// <summary>Withholding tax settlement.</summary>
+    [JsonStringEnumMemberName("WITHHOLDING_TAX_SETTLEMENT")] WithholdingTaxSettlement,
+
+    /// <summary>Withholding tax rates.</summary>
+    [JsonStringEnumMemberName("WITHHOLDING_TAX_RATES")] WithholdingTaxRates,
+
+    /// <summary>Cash flow chart.</summary>
+    [JsonStringEnumMemberName("CASH_FLOW_CHART")] CashFlowChart,
+
+    /// <summary>Free-form text + image block.</summary>
+    [JsonStringEnumMemberName("TEXT_IMAGE")] TextImage
+}

--- a/src/CashCtrlApiNet.Abstractions/Models/Report/Element/ReportElementMeta.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Report/Element/ReportElementMeta.cs
@@ -1,0 +1,62 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json.Serialization;
+using CashCtrlApiNet.Abstractions.Models.Base;
+
+namespace CashCtrlApiNet.Abstractions.Models.Report.Element;
+
+/// <summary>
+/// Response shape for <c>/report/element/meta.json</c>. This is a slim "document header" view
+/// used when rendering a single report element — title, text, period label, and display flags.
+/// Distinct from <see cref="ReportElement"/> which is the element's configuration record.
+/// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/element/meta.json">API Doc</a>
+/// </summary>
+public record ReportElementMeta : ModelBaseRecord
+{
+    /// <summary>The element title shown as a heading in the rendered report.</summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>Free-form header text for the element.</summary>
+    [JsonPropertyName("text")]
+    public string? Text { get; init; }
+
+    /// <summary>Human-readable label for the reporting period (e.g. "2026").</summary>
+    [JsonPropertyName("periodLabel")]
+    public string? PeriodLabel { get; init; }
+
+    /// <summary>Whether the title should be hidden on the rendered report.</summary>
+    [JsonPropertyName("isHideTitle")]
+    public bool? IsHideTitle { get; init; }
+
+    /// <summary>Whether this report type is in beta status.</summary>
+    [JsonPropertyName("isBeta")]
+    public bool? IsBeta { get; init; }
+
+    /// <summary>Whether this report type requires a CashCtrl Pro subscription.</summary>
+    [JsonPropertyName("isPro")]
+    public bool? IsPro { get; init; }
+}

--- a/src/CashCtrlApiNet.Abstractions/Models/Report/Element/ReportElementRequest.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Report/Element/ReportElementRequest.cs
@@ -24,63 +24,55 @@ SOFTWARE.
 */
 
 using System.Text.Json.Serialization;
-using CashCtrlApiNet.Abstractions.Enums.Report;
 using CashCtrlApiNet.Abstractions.Models.Base;
 
 namespace CashCtrlApiNet.Abstractions.Models.Report.Element;
 
 /// <summary>
-/// Report element create. <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/element/create.json">API Doc</a>
+/// Request parameters for the report element data/meta/download endpoints
+/// (<c>/report/element/data.json</c>, <c>data.html</c>, <c>meta.json</c>,
+/// <c>download.pdf</c>, <c>download.csv</c>, <c>download.xlsx</c>). These endpoints all take
+/// <c>elementId</c> as a mandatory query parameter (not <c>id</c> like the read endpoint) plus
+/// an optional reporting period.
+/// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/element/data.json">API Doc</a>
 /// </summary>
-public record ReportElementCreate : ModelBaseRecord
+public record ReportElementRequest : ModelBaseRecord
 {
     /// <summary>
-    /// The type of report this element renders. Mandatory — omitting it causes the API to reject
-    /// with <c>[type] Invalid value</c>.
+    /// The ID of the report element. Mandatory.
     /// </summary>
-    [JsonPropertyName("type")]
-    public required ReportElementType Type { get; init; }
+    [JsonPropertyName("elementId")]
+    public required int ElementId { get; init; }
 
     /// <summary>
-    /// The ID of the parent report collection (what CashCtrl used to call a "report set").
-    /// The API parameter is <c>collectionId</c>, not <c>reportId</c>.
+    /// The start date of the report period in <c>YYYY-MM-DD</c> format.
+    /// Overridden if <see cref="FiscalPeriod"/> is set.
     /// </summary>
-    [JsonPropertyName("collectionId")]
-    public int? CollectionId { get; init; }
+    [JsonPropertyName("startDate")]
+    public string? StartDate { get; init; }
 
     /// <summary>
-    /// The ID of the account.
+    /// The end date of the report period in <c>YYYY-MM-DD</c> format.
+    /// Overridden if <see cref="FiscalPeriod"/> is set.
     /// </summary>
-    [JsonPropertyName("accountId")]
-    public int? AccountId { get; init; }
+    [JsonPropertyName("endDate")]
+    public string? EndDate { get; init; }
 
     /// <summary>
-    /// The ID of the cost center category.
+    /// The ID of the fiscal period. Overrides <see cref="StartDate"/> / <see cref="EndDate"/>.
     /// </summary>
-    [JsonPropertyName("costCenterCategoryId")]
-    public int? CostCenterCategoryId { get; init; }
+    [JsonPropertyName("fiscalPeriod")]
+    public int? FiscalPeriod { get; init; }
 
     /// <summary>
-    /// The ID of the currency.
+    /// The language of the generated report. Possible values: <c>DE</c>, <c>EN</c>, <c>FR</c>, <c>IT</c>.
     /// </summary>
-    [JsonPropertyName("currencyId")]
-    public int? CurrencyId { get; init; }
+    [JsonPropertyName("language")]
+    public string? Language { get; init; }
 
     /// <summary>
-    /// The ID of the date filter.
+    /// The column to sort the report by.
     /// </summary>
-    [JsonPropertyName("dateFilterId")]
-    public int? DateFilterId { get; init; }
-
-    /// <summary>
-    /// Whether to include the total.
-    /// </summary>
-    [JsonPropertyName("includeTotal")]
-    public bool? IncludeTotal { get; init; }
-
-    /// <summary>
-    /// Whether to negate the amount.
-    /// </summary>
-    [JsonPropertyName("negateAmount")]
-    public bool? NegateAmount { get; init; }
+    [JsonPropertyName("sort")]
+    public string? Sort { get; init; }
 }

--- a/src/CashCtrlApiNet.Abstractions/Models/Report/Set/ReportAnnualReportRequest.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Report/Set/ReportAnnualReportRequest.cs
@@ -23,42 +23,21 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using System.Collections.Immutable;
 using System.Text.Json.Serialization;
-using CashCtrlApiNet.Abstractions.Converters;
 using CashCtrlApiNet.Abstractions.Models.Base;
 
-namespace CashCtrlApiNet.Abstractions.Models.Report.Element;
+namespace CashCtrlApiNet.Abstractions.Models.Report.Set;
 
 /// <summary>
-/// Report element reorder. <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/element/reorder.json">API Doc</a>
+/// Request parameters for <c>/report/collection/download_annualreport.pdf</c>. The endpoint is
+/// not scoped to a specific collection — it only takes an optional fiscal-period override.
+/// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/collection/download_annualreport.pdf">API Doc</a>
 /// </summary>
-public record ReportElementReorder : ModelBaseRecord
+public record ReportAnnualReportRequest : ModelBaseRecord
 {
     /// <summary>
-    /// The ID of the parent report collection containing the elements. Required — omitting it
-    /// causes the API to reject with <c>ID missing.</c> even though the docs don't list it.
-    /// Same pattern as <c>customfield/reorder.json</c> requiring <c>type</c> for scope.
+    /// The ID of the fiscal period to render. Leave empty to use the account's current fiscal period.
     /// </summary>
-    [JsonPropertyName("collectionId")]
-    public required int CollectionId { get; init; }
-
-    /// <summary>
-    /// The IDs of the entries to reorder, comma-separated.
-    /// </summary>
-    [JsonPropertyName("ids")]
-    [JsonConverter(typeof(IntArrayAsCsvJsonConverter))]
-    public required ImmutableArray<int> Ids { get; init; }
-
-    /// <summary>
-    /// The ID of the target entry.
-    /// </summary>
-    [JsonPropertyName("target")]
-    public required int Target { get; init; }
-
-    /// <summary>
-    /// Whether to insert before the target. Defaults to false (insert after).
-    /// </summary>
-    [JsonPropertyName("before")]
-    public bool? Before { get; init; }
+    [JsonPropertyName("fiscalPeriodId")]
+    public int? FiscalPeriodId { get; init; }
 }

--- a/src/CashCtrlApiNet.Abstractions/Models/Report/Set/ReportCollectionMeta.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Report/Set/ReportCollectionMeta.cs
@@ -1,0 +1,59 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json.Serialization;
+using CashCtrlApiNet.Abstractions.Models.Base;
+
+namespace CashCtrlApiNet.Abstractions.Models.Report.Set;
+
+/// <summary>
+/// Response shape for <c>/report/collection/meta.json</c>. This is a slim "document header" view
+/// used when rendering a collection — it carries the title/text for the cover page, a period
+/// label and the organization logo. It is distinct from <see cref="ReportSet"/>, which is the
+/// collection's configuration record returned by <c>/report/collection/read.json</c>.
+/// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/collection/meta.json">API Doc</a>
+/// </summary>
+public record ReportCollectionMeta : ModelBaseRecord
+{
+    /// <summary>The collection title rendered on the cover page.</summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>Free-form cover-page text for the collection.</summary>
+    [JsonPropertyName("text")]
+    public string? Text { get; init; }
+
+    /// <summary>Human-readable label for the reporting period (e.g. "2026").</summary>
+    [JsonPropertyName("periodLabel")]
+    public string? PeriodLabel { get; init; }
+
+    /// <summary>URL of the organization logo to include on the cover page.</summary>
+    [JsonPropertyName("logoUrl")]
+    public string? LogoUrl { get; init; }
+
+    /// <summary>Height of the organization logo in pixels.</summary>
+    [JsonPropertyName("logoHeight")]
+    public int? LogoHeight { get; init; }
+}

--- a/src/CashCtrlApiNet.Abstractions/Models/Report/Set/ReportCollectionRequest.cs
+++ b/src/CashCtrlApiNet.Abstractions/Models/Report/Set/ReportCollectionRequest.cs
@@ -1,0 +1,78 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json.Serialization;
+using CashCtrlApiNet.Abstractions.Models.Base;
+
+namespace CashCtrlApiNet.Abstractions.Models.Report.Set;
+
+/// <summary>
+/// Request parameters for the report collection meta/download endpoints
+/// (<c>/report/collection/meta.json</c>, <c>download.pdf</c>, <c>download.csv</c>,
+/// <c>download.xlsx</c>). These endpoints all take <c>collectionId</c> as a mandatory query
+/// parameter (not <c>id</c> like other endpoints) plus an optional reporting period.
+/// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/collection/meta.json">API Doc</a>
+/// </summary>
+public record ReportCollectionRequest : ModelBaseRecord
+{
+    /// <summary>
+    /// The ID of the report collection. Mandatory.
+    /// </summary>
+    [JsonPropertyName("collectionId")]
+    public required int CollectionId { get; init; }
+
+    /// <summary>
+    /// The start date of the report period in <c>YYYY-MM-DD</c> format.
+    /// Overridden if <see cref="FiscalPeriod"/> is set.
+    /// </summary>
+    [JsonPropertyName("startDate")]
+    public string? StartDate { get; init; }
+
+    /// <summary>
+    /// The end date of the report period in <c>YYYY-MM-DD</c> format.
+    /// Overridden if <see cref="FiscalPeriod"/> is set.
+    /// </summary>
+    [JsonPropertyName("endDate")]
+    public string? EndDate { get; init; }
+
+    /// <summary>
+    /// The ID of the fiscal period. Overrides <see cref="StartDate"/> / <see cref="EndDate"/>
+    /// — the report period is derived from the fiscal period instead.
+    /// </summary>
+    [JsonPropertyName("fiscalPeriod")]
+    public int? FiscalPeriod { get; init; }
+
+    /// <summary>
+    /// The language of the generated report. Possible values: <c>DE</c>, <c>EN</c>, <c>FR</c>, <c>IT</c>.
+    /// </summary>
+    [JsonPropertyName("language")]
+    public string? Language { get; init; }
+
+    /// <summary>
+    /// The column to sort the elements by.
+    /// </summary>
+    [JsonPropertyName("sort")]
+    public string? Sort { get; init; }
+}

--- a/src/CashCtrlApiNet/Interfaces/Connectors/Report/IReportElementService.cs
+++ b/src/CashCtrlApiNet/Interfaces/Connectors/Report/IReportElementService.cs
@@ -80,56 +80,60 @@ public interface IReportElementService
     public Task<ApiResult<NoContentResponse>> Reorder(ReportElementReorder reorder, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Get report element data as JSON.
+    /// Get report element data as JSON for the given time period. Takes mandatory <c>elementId</c>.
+    /// The response shape varies by report type (tree structure for ChartOfAccounts, flat list for
+    /// Journal, etc.) so this returns the untyped <see cref="ApiResult"/> with
+    /// <see cref="ApiResult.RawResponseContent"/> carrying the JSON body — callers parse into the
+    /// shape appropriate for their report type.
     /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/element/data.json">API Doc - Report/Element/Data JSON</a>
     /// </summary>
-    /// <param name="element">The entry containing the ID of the report element.</param>
+    /// <param name="request">Element ID + optional period filter.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<ApiResult<SingleResponse<ReportElement>>> GetData(Entry element, CancellationToken cancellationToken = default);
+    public Task<ApiResult> GetData(ReportElementRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Get report element data as HTML.
+    /// Get report element data as HTML for the given time period. Takes mandatory <c>elementId</c>.
     /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/element/data.html">API Doc - Report/Element/Data HTML</a>
     /// </summary>
-    /// <param name="element">The entry containing the ID of the report element.</param>
+    /// <param name="request">Element ID + optional period filter.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<ApiResult<BinaryResponse>> GetDataHtml(Entry element, CancellationToken cancellationToken = default);
+    public Task<ApiResult<BinaryResponse>> GetDataHtml(ReportElementRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Get report element meta data.
+    /// Get report element meta data for the given time period. Takes mandatory <c>elementId</c>.
     /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/element/meta.json">API Doc - Report/Element/Meta</a>
     /// </summary>
-    /// <param name="element">The entry containing the ID of the report element.</param>
+    /// <param name="request">Element ID + optional period filter.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<ApiResult<SingleResponse<ReportElement>>> GetMeta(Entry element, CancellationToken cancellationToken = default);
+    public Task<ApiResult<SingleResponse<ReportElementMeta>>> GetMeta(ReportElementRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Download report element as PDF.
+    /// Download report element as PDF for the given time period. Takes mandatory <c>elementId</c>.
     /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/element/download.pdf">API Doc - Report/Element/Download PDF</a>
     /// </summary>
-    /// <param name="element">The entry containing the ID of the report element.</param>
+    /// <param name="request">Element ID + optional period filter.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<ApiResult<BinaryResponse>> DownloadPdf(Entry element, CancellationToken cancellationToken = default);
+    public Task<ApiResult<BinaryResponse>> DownloadPdf(ReportElementRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Download report element as CSV.
+    /// Download report element as CSV for the given time period. Takes mandatory <c>elementId</c>.
     /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/element/download.csv">API Doc - Report/Element/Download CSV</a>
     /// </summary>
-    /// <param name="element">The entry containing the ID of the report element.</param>
+    /// <param name="request">Element ID + optional period filter.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<ApiResult<BinaryResponse>> DownloadCsv(Entry element, CancellationToken cancellationToken = default);
+    public Task<ApiResult<BinaryResponse>> DownloadCsv(ReportElementRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Download report element as Excel.
+    /// Download report element as Excel for the given time period. Takes mandatory <c>elementId</c>.
     /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/element/download.xlsx">API Doc - Report/Element/Download Excel</a>
     /// </summary>
-    /// <param name="element">The entry containing the ID of the report element.</param>
+    /// <param name="request">Element ID + optional period filter.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<ApiResult<BinaryResponse>> DownloadExcel(Entry element, CancellationToken cancellationToken = default);
+    public Task<ApiResult<BinaryResponse>> DownloadExcel(ReportElementRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/CashCtrlApiNet/Interfaces/Connectors/Report/IReportSetService.cs
+++ b/src/CashCtrlApiNet/Interfaces/Connectors/Report/IReportSetService.cs
@@ -80,47 +80,51 @@ public interface IReportSetService
     public Task<ApiResult<NoContentResponse>> Reorder(ReportSetReorder reorder, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Get report set meta data.
-    /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/collection/meta.json">API Doc - Report/Set/Meta</a>
+    /// Get report collection meta data (title, text, etc.) for a given time period.
+    /// Takes mandatory <c>collectionId</c> — not <c>id</c> like the other read endpoints.
+    /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/collection/meta.json">API Doc - Report/Collection/Meta</a>
     /// </summary>
-    /// <param name="set">The entry containing the ID of the report set.</param>
+    /// <param name="request">Collection ID + optional period filter.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<ApiResult<SingleResponse<ReportSet>>> GetMeta(Entry set, CancellationToken cancellationToken = default);
+    public Task<ApiResult<SingleResponse<ReportCollectionMeta>>> GetMeta(ReportCollectionRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Download report set as PDF.
-    /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/collection/download.pdf">API Doc - Report/Set/Download PDF</a>
+    /// Download report collection as PDF for a given time period. Mandatory <c>collectionId</c>.
+    /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/collection/download.pdf">API Doc - Report/Collection/Download PDF</a>
     /// </summary>
-    /// <param name="set">The entry containing the ID of the report set.</param>
+    /// <param name="request">Collection ID + optional period filter.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<ApiResult<BinaryResponse>> DownloadPdf(Entry set, CancellationToken cancellationToken = default);
+    public Task<ApiResult<BinaryResponse>> DownloadPdf(ReportCollectionRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Download report set as CSV.
-    /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/collection/download.csv">API Doc - Report/Set/Download CSV</a>
+    /// Download report collection as a ZIP of CSV files for a given time period.
+    /// Mandatory <c>collectionId</c>.
+    /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/collection/download.csv">API Doc - Report/Collection/Download CSV</a>
     /// </summary>
-    /// <param name="set">The entry containing the ID of the report set.</param>
+    /// <param name="request">Collection ID + optional period filter.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<ApiResult<BinaryResponse>> DownloadCsv(Entry set, CancellationToken cancellationToken = default);
+    public Task<ApiResult<BinaryResponse>> DownloadCsv(ReportCollectionRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Download report set as Excel.
-    /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/collection/download.xlsx">API Doc - Report/Set/Download Excel</a>
+    /// Download report collection as Excel (one worksheet per element) for a given time period.
+    /// Mandatory <c>collectionId</c>.
+    /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/collection/download.xlsx">API Doc - Report/Collection/Download Excel</a>
     /// </summary>
-    /// <param name="set">The entry containing the ID of the report set.</param>
+    /// <param name="request">Collection ID + optional period filter.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<ApiResult<BinaryResponse>> DownloadExcel(Entry set, CancellationToken cancellationToken = default);
+    public Task<ApiResult<BinaryResponse>> DownloadExcel(ReportCollectionRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Download annual report as PDF.
-    /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/collection/download_annualreport.pdf">API Doc - Report/Set/Download Annual Report</a>
+    /// Download the annual report (balance sheet and P&amp;L by default) as PDF. Not scoped to a
+    /// specific collection; takes only an optional fiscal-period override.
+    /// <a href="https://app.cashctrl.com/static/help/en/api/index.html#/report/collection/download_annualreport.pdf">API Doc - Report/Collection/Download Annual Report</a>
     /// </summary>
-    /// <param name="set">The entry containing the ID of the report set.</param>
+    /// <param name="request">Optional fiscal-period override (pass <c>new()</c> for the current period).</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<ApiResult<BinaryResponse>> DownloadAnnualReport(Entry set, CancellationToken cancellationToken = default);
+    public Task<ApiResult<BinaryResponse>> DownloadAnnualReport(ReportAnnualReportRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/CashCtrlApiNet/Services/CashCtrlConnectionHandler.cs
+++ b/src/CashCtrlApiNet/Services/CashCtrlConnectionHandler.cs
@@ -270,12 +270,21 @@ public class CashCtrlConnectionHandler : ICashCtrlConnectionHandler, IDisposable
     }
 
     /// <summary>
-    /// Get API result from http response
+    /// Build an untyped <see cref="ApiResult"/>. Used by endpoints whose response shape is not a
+    /// fixed typed envelope (e.g. <c>/report/element/data.json</c> where the body structure varies
+    /// by report type) — the raw JSON body is carried through on <see cref="ApiResult.RawResponseContent"/>
+    /// so callers can parse it into whatever shape suits their report type.
     /// </summary>
     /// <param name="httpResponseMessage"></param>
     /// <returns></returns>
     private static async Task<ApiResult> GetApiResult(HttpResponseMessage httpResponseMessage)
-        => CreateApiResult<ApiResponse>(await GetData(httpResponseMessage));
+    {
+        var data = await GetData(httpResponseMessage);
+        return CreateApiResult<ApiResponse>(data) with
+        {
+            RawResponseContent = data.Content
+        };
+    }
 
     /// <summary>
     /// Get API result with decimal balance from http response

--- a/src/CashCtrlApiNet/Services/Connectors/Report/ReportElementService.cs
+++ b/src/CashCtrlApiNet/Services/Connectors/Report/ReportElementService.cs
@@ -57,26 +57,26 @@ public class ReportElementService(ICashCtrlConnectionHandler connectionHandler) 
         => ConnectionHandler.PostAsync<NoContentResponse, ReportElementReorder>(Endpoint.Reorder, reorder, cancellationToken: cancellationToken);
 
     /// <inheritdoc />
-    public Task<ApiResult<SingleResponse<ReportElement>>> GetData(Entry element, CancellationToken cancellationToken = default)
-        => ConnectionHandler.GetAsync<SingleResponse<ReportElement>, Entry>(Endpoint.ReadJson, element, cancellationToken);
+    public Task<ApiResult> GetData(ReportElementRequest request, CancellationToken cancellationToken = default)
+        => ConnectionHandler.GetAsync(Endpoint.ReadJson, request, cancellationToken);
 
     /// <inheritdoc />
-    public Task<ApiResult<BinaryResponse>> GetDataHtml(Entry element, CancellationToken cancellationToken = default)
-        => ConnectionHandler.GetBinaryAsync(Endpoint.ReadHtml, element, cancellationToken);
+    public Task<ApiResult<BinaryResponse>> GetDataHtml(ReportElementRequest request, CancellationToken cancellationToken = default)
+        => ConnectionHandler.GetBinaryAsync(Endpoint.ReadHtml, request, cancellationToken);
 
     /// <inheritdoc />
-    public Task<ApiResult<SingleResponse<ReportElement>>> GetMeta(Entry element, CancellationToken cancellationToken = default)
-        => ConnectionHandler.GetAsync<SingleResponse<ReportElement>, Entry>(Endpoint.ReadMeta, element, cancellationToken);
+    public Task<ApiResult<SingleResponse<ReportElementMeta>>> GetMeta(ReportElementRequest request, CancellationToken cancellationToken = default)
+        => ConnectionHandler.GetAsync<SingleResponse<ReportElementMeta>, ReportElementRequest>(Endpoint.ReadMeta, request, cancellationToken);
 
     /// <inheritdoc />
-    public Task<ApiResult<BinaryResponse>> DownloadPdf(Entry element, CancellationToken cancellationToken = default)
-        => ConnectionHandler.GetBinaryAsync(Endpoint.DownloadPdf, element, cancellationToken);
+    public Task<ApiResult<BinaryResponse>> DownloadPdf(ReportElementRequest request, CancellationToken cancellationToken = default)
+        => ConnectionHandler.GetBinaryAsync(Endpoint.DownloadPdf, request, cancellationToken);
 
     /// <inheritdoc />
-    public Task<ApiResult<BinaryResponse>> DownloadCsv(Entry element, CancellationToken cancellationToken = default)
-        => ConnectionHandler.GetBinaryAsync(Endpoint.DownloadCsv, element, cancellationToken);
+    public Task<ApiResult<BinaryResponse>> DownloadCsv(ReportElementRequest request, CancellationToken cancellationToken = default)
+        => ConnectionHandler.GetBinaryAsync(Endpoint.DownloadCsv, request, cancellationToken);
 
     /// <inheritdoc />
-    public Task<ApiResult<BinaryResponse>> DownloadExcel(Entry element, CancellationToken cancellationToken = default)
-        => ConnectionHandler.GetBinaryAsync(Endpoint.DownloadXlsx, element, cancellationToken);
+    public Task<ApiResult<BinaryResponse>> DownloadExcel(ReportElementRequest request, CancellationToken cancellationToken = default)
+        => ConnectionHandler.GetBinaryAsync(Endpoint.DownloadXlsx, request, cancellationToken);
 }

--- a/src/CashCtrlApiNet/Services/Connectors/Report/ReportSetService.cs
+++ b/src/CashCtrlApiNet/Services/Connectors/Report/ReportSetService.cs
@@ -57,22 +57,22 @@ public class ReportSetService(ICashCtrlConnectionHandler connectionHandler) : Co
         => ConnectionHandler.PostAsync<NoContentResponse, ReportSetReorder>(Endpoint.Reorder, reorder, cancellationToken: cancellationToken);
 
     /// <inheritdoc />
-    public Task<ApiResult<SingleResponse<ReportSet>>> GetMeta(Entry set, CancellationToken cancellationToken = default)
-        => ConnectionHandler.GetAsync<SingleResponse<ReportSet>, Entry>(Endpoint.ReadMeta, set, cancellationToken);
+    public Task<ApiResult<SingleResponse<ReportCollectionMeta>>> GetMeta(ReportCollectionRequest request, CancellationToken cancellationToken = default)
+        => ConnectionHandler.GetAsync<SingleResponse<ReportCollectionMeta>, ReportCollectionRequest>(Endpoint.ReadMeta, request, cancellationToken);
 
     /// <inheritdoc />
-    public Task<ApiResult<BinaryResponse>> DownloadPdf(Entry set, CancellationToken cancellationToken = default)
-        => ConnectionHandler.GetBinaryAsync(Endpoint.DownloadPdf, set, cancellationToken);
+    public Task<ApiResult<BinaryResponse>> DownloadPdf(ReportCollectionRequest request, CancellationToken cancellationToken = default)
+        => ConnectionHandler.GetBinaryAsync(Endpoint.DownloadPdf, request, cancellationToken);
 
     /// <inheritdoc />
-    public Task<ApiResult<BinaryResponse>> DownloadCsv(Entry set, CancellationToken cancellationToken = default)
-        => ConnectionHandler.GetBinaryAsync(Endpoint.DownloadCsv, set, cancellationToken);
+    public Task<ApiResult<BinaryResponse>> DownloadCsv(ReportCollectionRequest request, CancellationToken cancellationToken = default)
+        => ConnectionHandler.GetBinaryAsync(Endpoint.DownloadCsv, request, cancellationToken);
 
     /// <inheritdoc />
-    public Task<ApiResult<BinaryResponse>> DownloadExcel(Entry set, CancellationToken cancellationToken = default)
-        => ConnectionHandler.GetBinaryAsync(Endpoint.DownloadXlsx, set, cancellationToken);
+    public Task<ApiResult<BinaryResponse>> DownloadExcel(ReportCollectionRequest request, CancellationToken cancellationToken = default)
+        => ConnectionHandler.GetBinaryAsync(Endpoint.DownloadXlsx, request, cancellationToken);
 
     /// <inheritdoc />
-    public Task<ApiResult<BinaryResponse>> DownloadAnnualReport(Entry set, CancellationToken cancellationToken = default)
-        => ConnectionHandler.GetBinaryAsync(Endpoint.DownloadAnnualReport, set, cancellationToken);
+    public Task<ApiResult<BinaryResponse>> DownloadAnnualReport(ReportAnnualReportRequest request, CancellationToken cancellationToken = default)
+        => ConnectionHandler.GetBinaryAsync(Endpoint.DownloadAnnualReport, request, cancellationToken);
 }

--- a/tests/CashCtrlApiNet.E2eTests/Report/ReportElementE2eTests.cs
+++ b/tests/CashCtrlApiNet.E2eTests/Report/ReportElementE2eTests.cs
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+using CashCtrlApiNet.Abstractions.Enums.Report;
 using CashCtrlApiNet.Abstractions.Models.Report.Element;
 using Shouldly;
 
@@ -70,7 +71,8 @@ public class ReportElementE2eTests : CashCtrlE2eTestBase
         // Create primary test report element
         var createResult = await CashCtrlApiClient.Report.Element.Create(new()
         {
-            ReportId = _reportSetId,
+            Type = ReportElementType.ChartOfAccounts,
+            CollectionId = _reportSetId,
             AccountId = _accountId
         });
         _setupElementId = AssertCreated(createResult);
@@ -80,7 +82,8 @@ public class ReportElementE2eTests : CashCtrlE2eTestBase
         // Create a second element for reorder test
         var secondResult = await CashCtrlApiClient.Report.Element.Create(new()
         {
-            ReportId = _reportSetId,
+            Type = ReportElementType.ChartOfAccounts,
+            CollectionId = _reportSetId,
             AccountId = _accountId
         });
         _secondElementId = AssertCreated(secondResult);
@@ -107,8 +110,11 @@ public class ReportElementE2eTests : CashCtrlE2eTestBase
         res.RequestsLeft.Value.ShouldBeGreaterThan(0);
         res.CashCtrlHttpStatusCodeDescription.ShouldNotBeNullOrEmpty();
 
-        element.ReportId.ShouldBe(_reportSetId);
-        element.AccountId.ShouldBe(_accountId);
+        element.CollectionId.ShouldBe(_reportSetId);
+        // AccountId is roundtripped only by report types that have a primary account dimension;
+        // ChartOfAccounts stores the whole chart so it leaves accountId null. Just assert
+        // deserialization worked.
+        element.Type.ShouldBe(ReportElementType.ChartOfAccounts);
     }
 
     /// <summary>
@@ -119,7 +125,8 @@ public class ReportElementE2eTests : CashCtrlE2eTestBase
     {
         var res = await CashCtrlApiClient.Report.Element.Create(new()
         {
-            ReportId = _reportSetId,
+            Type = ReportElementType.ChartOfAccounts,
+            CollectionId = _reportSetId,
             AccountId = _accountId
         });
 
@@ -143,9 +150,9 @@ public class ReportElementE2eTests : CashCtrlE2eTestBase
         });
         AssertSuccess(res);
 
-        // Verify the update persisted
-        var verify = await CashCtrlApiClient.Report.Element.Get(new() { Id = _setupElementId });
-        verify.ResponseData?.Data?.NegateAmount.ShouldBe(true);
+        // No round-trip verify: ChartOfAccounts elements silently discard the NegateAmount flag
+        // on read (the field is only meaningful for report types with a primary amount dimension).
+        // Asserting HTTP success on Update is the strongest signal we can get here.
     }
 
     /// <summary>
@@ -156,6 +163,7 @@ public class ReportElementE2eTests : CashCtrlE2eTestBase
     {
         var res = await CashCtrlApiClient.Report.Element.Reorder(new()
         {
+            CollectionId = _reportSetId,
             Ids = [_secondElementId],
             Target = _setupElementId
         });
@@ -163,25 +171,36 @@ public class ReportElementE2eTests : CashCtrlE2eTestBase
     }
 
     /// <summary>
-    /// Get report element data as JSON successfully
+    /// Get report element data as JSON successfully. GetData returns an untyped
+    /// <see cref="CashCtrlApiNet.Abstractions.Models.Api.ApiResult"/> because the response shape
+    /// varies by report type — callers parse <c>RawResponseContent</c> into the shape for their
+    /// specific report type (tree for ChartOfAccounts, flat list for Journal, etc.).
     /// </summary>
     [Test, Order(5)]
     public async Task GetData_Success()
     {
-        var res = await CashCtrlApiClient.Report.Element.GetData(new() { Id = _setupElementId });
-        var data = AssertSuccess(res);
+        var res = await CashCtrlApiClient.Report.Element.GetData(new() { ElementId = _setupElementId });
 
-        data.ShouldNotBeNull();
+        res.IsHttpSuccess.ShouldBeTrue();
+        res.RawResponseContent.ShouldNotBeNullOrEmpty();
     }
 
     /// <summary>
-    /// Get report element data as HTML successfully
+    /// Get report element data as HTML successfully. Unlike the PDF/CSV/Excel downloads, the HTML
+    /// endpoint serves the body inline with no <c>Content-Disposition: attachment</c> header, so
+    /// <see cref="CashCtrlApiNet.Abstractions.Models.Api.BinaryResponse.FileName"/> is null — we
+    /// assert on payload bytes and synthesize a filename for the optional local download.
     /// </summary>
     [Test, Order(6)]
     public async Task GetDataHtml_Success()
     {
-        var export = AssertSuccess(await CashCtrlApiClient.Report.Element.GetDataHtml(new() { Id = _setupElementId }));
-        await DownloadFile(export.FileName!, export.Data);
+        var res = await CashCtrlApiClient.Report.Element.GetDataHtml(new() { ElementId = _setupElementId });
+
+        res.IsHttpSuccess.ShouldBeTrue();
+        res.ResponseData.ShouldNotBeNull();
+        res.ResponseData.Data.Length.ShouldBeGreaterThan(0);
+
+        await DownloadFile(res.ResponseData.FileName ?? $"report-element-{_setupElementId}.html", res.ResponseData.Data);
     }
 
     /// <summary>
@@ -190,7 +209,7 @@ public class ReportElementE2eTests : CashCtrlE2eTestBase
     [Test, Order(7)]
     public async Task GetMeta_Success()
     {
-        var res = await CashCtrlApiClient.Report.Element.GetMeta(new() { Id = _setupElementId });
+        var res = await CashCtrlApiClient.Report.Element.GetMeta(new() { ElementId = _setupElementId });
         var meta = AssertSuccess(res);
 
         meta.ShouldNotBeNull();
@@ -202,7 +221,7 @@ public class ReportElementE2eTests : CashCtrlE2eTestBase
     [Test, Order(8)]
     public async Task DownloadPdf_Success()
     {
-        var export = AssertSuccess(await CashCtrlApiClient.Report.Element.DownloadPdf(new() { Id = _setupElementId }));
+        var export = AssertSuccess(await CashCtrlApiClient.Report.Element.DownloadPdf(new() { ElementId = _setupElementId }));
         await DownloadFile(export.FileName!, export.Data);
     }
 
@@ -212,7 +231,7 @@ public class ReportElementE2eTests : CashCtrlE2eTestBase
     [Test, Order(9)]
     public async Task DownloadCsv_Success()
     {
-        var export = AssertSuccess(await CashCtrlApiClient.Report.Element.DownloadCsv(new() { Id = _setupElementId }));
+        var export = AssertSuccess(await CashCtrlApiClient.Report.Element.DownloadCsv(new() { ElementId = _setupElementId }));
         await DownloadFile(export.FileName!, export.Data);
     }
 
@@ -222,7 +241,7 @@ public class ReportElementE2eTests : CashCtrlE2eTestBase
     [Test, Order(10)]
     public async Task DownloadExcel_Success()
     {
-        var export = AssertSuccess(await CashCtrlApiClient.Report.Element.DownloadExcel(new() { Id = _setupElementId }));
+        var export = AssertSuccess(await CashCtrlApiClient.Report.Element.DownloadExcel(new() { ElementId = _setupElementId }));
         await DownloadFile(export.FileName!, export.Data);
     }
 

--- a/tests/CashCtrlApiNet.E2eTests/Report/ReportSetE2eTests.cs
+++ b/tests/CashCtrlApiNet.E2eTests/Report/ReportSetE2eTests.cs
@@ -149,7 +149,7 @@ public class ReportSetE2eTests : CashCtrlE2eTestBase
     [Test, Order(5)]
     public async Task GetMeta_Success()
     {
-        var res = await CashCtrlApiClient.Report.Set.GetMeta(new() { Id = _setupSetId });
+        var res = await CashCtrlApiClient.Report.Set.GetMeta(new() { CollectionId = _setupSetId });
         var meta = AssertSuccess(res);
 
         meta.ShouldNotBeNull();
@@ -161,7 +161,7 @@ public class ReportSetE2eTests : CashCtrlE2eTestBase
     [Test, Order(6)]
     public async Task DownloadPdf_Success()
     {
-        var export = AssertSuccess(await CashCtrlApiClient.Report.Set.DownloadPdf(new() { Id = _setupSetId }));
+        var export = AssertSuccess(await CashCtrlApiClient.Report.Set.DownloadPdf(new() { CollectionId = _setupSetId }));
         await DownloadFile(export.FileName!, export.Data);
     }
 
@@ -171,7 +171,7 @@ public class ReportSetE2eTests : CashCtrlE2eTestBase
     [Test, Order(7)]
     public async Task DownloadCsv_Success()
     {
-        var export = AssertSuccess(await CashCtrlApiClient.Report.Set.DownloadCsv(new() { Id = _setupSetId }));
+        var export = AssertSuccess(await CashCtrlApiClient.Report.Set.DownloadCsv(new() { CollectionId = _setupSetId }));
         await DownloadFile(export.FileName!, export.Data);
     }
 
@@ -181,7 +181,7 @@ public class ReportSetE2eTests : CashCtrlE2eTestBase
     [Test, Order(8)]
     public async Task DownloadExcel_Success()
     {
-        var export = AssertSuccess(await CashCtrlApiClient.Report.Set.DownloadExcel(new() { Id = _setupSetId }));
+        var export = AssertSuccess(await CashCtrlApiClient.Report.Set.DownloadExcel(new() { CollectionId = _setupSetId }));
         await DownloadFile(export.FileName!, export.Data);
     }
 
@@ -191,7 +191,7 @@ public class ReportSetE2eTests : CashCtrlE2eTestBase
     [Test, Order(9)]
     public async Task DownloadAnnualReport_Success()
     {
-        var export = AssertSuccess(await CashCtrlApiClient.Report.Set.DownloadAnnualReport(new() { Id = _setupSetId }));
+        var export = AssertSuccess(await CashCtrlApiClient.Report.Set.DownloadAnnualReport(new()));
         await DownloadFile(export.FileName!, export.Data);
     }
 

--- a/tests/CashCtrlApiNet.IntegrationTests/Fakers/ReportFakers.cs
+++ b/tests/CashCtrlApiNet.IntegrationTests/Fakers/ReportFakers.cs
@@ -24,6 +24,7 @@ SOFTWARE.
 */
 
 using Bogus;
+using CashCtrlApiNet.Abstractions.Enums.Report;
 using ReportModel = CashCtrlApiNet.Abstractions.Models.Report.Report;
 using ReportElementModel = CashCtrlApiNet.Abstractions.Models.Report.Element.ReportElement;
 using ReportElementCreateModel = CashCtrlApiNet.Abstractions.Models.Report.Element.ReportElementCreate;
@@ -58,7 +59,8 @@ public static class ReportFakers
         .CustomInstantiator(f => new()
         {
             Id = f.Random.Int(1, 9999),
-            ReportId = f.Random.Int(1, 100),
+            Type = ReportElementType.ChartOfAccounts,
+            CollectionId = f.Random.Int(1, 100),
             AccountId = f.Random.Int(1, 100),
             CostCenterCategoryId = f.Random.Int(1, 100),
             CurrencyId = f.Random.Int(1, 10),
@@ -75,7 +77,8 @@ public static class ReportFakers
     public static readonly Faker<ReportElementCreateModel> ReportElementCreate = new Faker<ReportElementCreateModel>()
         .CustomInstantiator(f => new()
         {
-            ReportId = f.Random.Int(1, 100),
+            Type = ReportElementType.ChartOfAccounts,
+            CollectionId = f.Random.Int(1, 100),
             AccountId = f.Random.Int(1, 100)
         });
 
@@ -86,7 +89,8 @@ public static class ReportFakers
         .CustomInstantiator(f => new()
         {
             Id = f.Random.Int(1, 9999),
-            ReportId = f.Random.Int(1, 100),
+            Type = ReportElementType.ChartOfAccounts,
+            CollectionId = f.Random.Int(1, 100),
             AccountId = f.Random.Int(1, 100),
             IncludeTotal = f.Random.Bool(),
             NegateAmount = f.Random.Bool()

--- a/tests/CashCtrlApiNet.IntegrationTests/Report/ReportElementServiceIntegrationTests.cs
+++ b/tests/CashCtrlApiNet.IntegrationTests/Report/ReportElementServiceIntegrationTests.cs
@@ -53,7 +53,7 @@ public class ReportElementServiceIntegrationTests : IntegrationTestBase
         result.ResponseData.ShouldNotBeNull();
         result.ResponseData.Data.ShouldNotBeNull();
         result.ResponseData.Data.Id.ShouldBe(element.Id);
-        result.ResponseData.Data.ReportId.ShouldBe(element.ReportId);
+        result.ResponseData.Data.CollectionId.ShouldBe(element.CollectionId);
         result.ResponseData.Data.AccountId.ShouldBe(element.AccountId);
     }
 
@@ -133,6 +133,7 @@ public class ReportElementServiceIntegrationTests : IntegrationTestBase
         // Act
         var result = await Client.Report.Element.Reorder(new()
         {
+            CollectionId = 10,
             Ids = [1, 2, 3],
             Target = 5
         });
@@ -145,24 +146,24 @@ public class ReportElementServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    /// Verify GetData returns a single report element with data
+    /// Verify GetData returns the raw JSON body untouched — its shape varies by report type
+    /// (tree structure for ChartOfAccounts, flat list for Journal, etc.), so the service returns
+    /// an untyped <see cref="CashCtrlApiNet.Abstractions.Models.Api.ApiResult"/> and callers parse
+    /// <c>RawResponseContent</c> into the shape appropriate for their report type.
     /// </summary>
     [Test]
     public async Task GetData_ReturnsExpectedResult()
     {
-        // Arrange
-        var element = ReportFakers.ReportElement.Generate();
-        Server.StubGetJson("/api/v1/report/element/data.json",
-            CashCtrlResponseFactory.SingleResponse(element));
+        // Arrange: ChartOfAccounts returns a tree node payload, not a flat single-entity shape
+        const string rawJson = """{"success":true,"data":[{"id":1,"name":"Assets","accounts":[]}]}""";
+        Server.StubGetJson("/api/v1/report/element/data.json", rawJson);
 
         // Act
-        var result = await Client.Report.Element.GetData(new() { Id = element.Id });
+        var result = await Client.Report.Element.GetData(new() { ElementId = 1 });
 
         // Assert
         result.IsHttpSuccess.ShouldBeTrue();
-        result.ResponseData.ShouldNotBeNull();
-        result.ResponseData.Data.ShouldNotBeNull();
-        result.ResponseData.Data.Id.ShouldBe(element.Id);
+        result.RawResponseContent.ShouldBe(rawJson);
     }
 
     /// <summary>
@@ -177,7 +178,7 @@ public class ReportElementServiceIntegrationTests : IntegrationTestBase
             "text/html", "report.html");
 
         // Act
-        var result = await Client.Report.Element.GetDataHtml(new() { Id = 1 });
+        var result = await Client.Report.Element.GetDataHtml(new() { ElementId = 1 });
 
         // Assert
         result.IsHttpSuccess.ShouldBeTrue();
@@ -186,24 +187,26 @@ public class ReportElementServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    /// Verify GetMeta returns a single report element with metadata
+    /// Verify GetMeta returns the element's document header (title, text, period label, flags).
+    /// The meta shape is distinct from <see cref="CashCtrlApiNet.Abstractions.Models.Report.Element.ReportElement"/>
+    /// and carries no <c>id</c> field.
     /// </summary>
     [Test]
     public async Task GetMeta_ReturnsExpectedResult()
     {
-        // Arrange
-        var element = ReportFakers.ReportElement.Generate();
+        // Arrange: the meta endpoint returns a slim header payload, not the element's config record.
         Server.StubGetJson("/api/v1/report/element/meta.json",
-            CashCtrlResponseFactory.SingleResponse(element));
+            """{"success":true,"data":{"title":"Chart of accounts","text":"","periodLabel":"2026","isHideTitle":false,"isBeta":false,"isPro":false}}""");
 
         // Act
-        var result = await Client.Report.Element.GetMeta(new() { Id = element.Id });
+        var result = await Client.Report.Element.GetMeta(new() { ElementId = 1 });
 
         // Assert
         result.IsHttpSuccess.ShouldBeTrue();
         result.ResponseData.ShouldNotBeNull();
         result.ResponseData.Data.ShouldNotBeNull();
-        result.ResponseData.Data.Id.ShouldBe(element.Id);
+        result.ResponseData.Data.Title.ShouldBe("Chart of accounts");
+        result.ResponseData.Data.PeriodLabel.ShouldBe("2026");
     }
 
     /// <summary>
@@ -218,7 +221,7 @@ public class ReportElementServiceIntegrationTests : IntegrationTestBase
             "application/pdf", "report-element.pdf");
 
         // Act
-        var result = await Client.Report.Element.DownloadPdf(new() { Id = 1 });
+        var result = await Client.Report.Element.DownloadPdf(new() { ElementId = 1 });
 
         // Assert
         result.IsHttpSuccess.ShouldBeTrue();
@@ -238,7 +241,7 @@ public class ReportElementServiceIntegrationTests : IntegrationTestBase
             "text/csv", "report-element.csv");
 
         // Act
-        var result = await Client.Report.Element.DownloadCsv(new() { Id = 1 });
+        var result = await Client.Report.Element.DownloadCsv(new() { ElementId = 1 });
 
         // Assert
         result.IsHttpSuccess.ShouldBeTrue();
@@ -258,7 +261,7 @@ public class ReportElementServiceIntegrationTests : IntegrationTestBase
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "report-element.xlsx");
 
         // Act
-        var result = await Client.Report.Element.DownloadExcel(new() { Id = 1 });
+        var result = await Client.Report.Element.DownloadExcel(new() { ElementId = 1 });
 
         // Assert
         result.IsHttpSuccess.ShouldBeTrue();

--- a/tests/CashCtrlApiNet.IntegrationTests/Report/ReportSetServiceIntegrationTests.cs
+++ b/tests/CashCtrlApiNet.IntegrationTests/Report/ReportSetServiceIntegrationTests.cs
@@ -155,14 +155,21 @@ public class ReportSetServiceIntegrationTests : IntegrationTestBase
         Server.StubGetJson("/api/v1/report/collection/meta.json",
             CashCtrlResponseFactory.SingleResponse(reportSet));
 
+        // Arrange: stub returns the collection-meta shape (title + periodLabel + logo info),
+        // not the full ReportSet shape.
+        Server.ResetMappings();
+        Server.StubGetJson("/api/v1/report/collection/meta.json",
+            """{"success":true,"data":{"title":"My Report","text":"","periodLabel":"2026","logoUrl":null,"logoHeight":null}}""");
+
         // Act
-        var result = await Client.Report.Set.GetMeta(new() { Id = reportSet.Id });
+        var result = await Client.Report.Set.GetMeta(new() { CollectionId = reportSet.Id });
 
         // Assert
         result.IsHttpSuccess.ShouldBeTrue();
         result.ResponseData.ShouldNotBeNull();
         result.ResponseData.Data.ShouldNotBeNull();
-        result.ResponseData.Data.Id.ShouldBe(reportSet.Id);
+        result.ResponseData.Data.Title.ShouldBe("My Report");
+        result.ResponseData.Data.PeriodLabel.ShouldBe("2026");
     }
 
     /// <summary>
@@ -177,7 +184,7 @@ public class ReportSetServiceIntegrationTests : IntegrationTestBase
             "application/pdf", "report-set.pdf");
 
         // Act
-        var result = await Client.Report.Set.DownloadPdf(new() { Id = 1 });
+        var result = await Client.Report.Set.DownloadPdf(new() { CollectionId = 1 });
 
         // Assert
         result.IsHttpSuccess.ShouldBeTrue();
@@ -197,7 +204,7 @@ public class ReportSetServiceIntegrationTests : IntegrationTestBase
             "text/csv", "report-set.csv");
 
         // Act
-        var result = await Client.Report.Set.DownloadCsv(new() { Id = 1 });
+        var result = await Client.Report.Set.DownloadCsv(new() { CollectionId = 1 });
 
         // Assert
         result.IsHttpSuccess.ShouldBeTrue();
@@ -217,7 +224,7 @@ public class ReportSetServiceIntegrationTests : IntegrationTestBase
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "report-set.xlsx");
 
         // Act
-        var result = await Client.Report.Set.DownloadExcel(new() { Id = 1 });
+        var result = await Client.Report.Set.DownloadExcel(new() { CollectionId = 1 });
 
         // Assert
         result.IsHttpSuccess.ShouldBeTrue();
@@ -237,7 +244,7 @@ public class ReportSetServiceIntegrationTests : IntegrationTestBase
             "application/pdf", "annual-report.pdf");
 
         // Act
-        var result = await Client.Report.Set.DownloadAnnualReport(new() { Id = 1 });
+        var result = await Client.Report.Set.DownloadAnnualReport(new());
 
         // Assert
         result.IsHttpSuccess.ShouldBeTrue();

--- a/tests/CashCtrlApiNet.UnitTests/Report/ReportElementServiceTests.cs
+++ b/tests/CashCtrlApiNet.UnitTests/Report/ReportElementServiceTests.cs
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+using CashCtrlApiNet.Abstractions.Enums.Report;
 using CashCtrlApiNet.Abstractions.Models.Api;
 using CashCtrlApiNet.Abstractions.Models.Base;
 using CashCtrlApiNet.Abstractions.Models.Report.Element;
@@ -61,7 +62,7 @@ public class ReportElementServiceTests : ServiceTestBase<ReportElementService>
     [Test]
     public async Task Create_ShouldPostToCorrectEndpoint()
     {
-        var element = new ReportElementCreate { ReportId = 1, AccountId = 2 };
+        var element = new ReportElementCreate { Type = ReportElementType.ChartOfAccounts, CollectionId = 1, AccountId = 2 };
         ConnectionHandler
             .PostAsync<NoContentResponse, ReportElementCreate>(Arg.Any<string>(), Arg.Any<ReportElementCreate>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<NoContentResponse>());
@@ -76,7 +77,7 @@ public class ReportElementServiceTests : ServiceTestBase<ReportElementService>
     [Test]
     public async Task Update_ShouldPostToCorrectEndpoint()
     {
-        var element = new ReportElementUpdate { Id = 1, ReportId = 1, AccountId = 2 };
+        var element = new ReportElementUpdate { Id = 1, Type = ReportElementType.ChartOfAccounts, CollectionId = 1, AccountId = 2 };
         ConnectionHandler
             .PostAsync<NoContentResponse, ReportElementUpdate>(Arg.Any<string>(), Arg.Any<ReportElementUpdate>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<NoContentResponse>());
@@ -106,7 +107,7 @@ public class ReportElementServiceTests : ServiceTestBase<ReportElementService>
     [Test]
     public async Task Reorder_ShouldPostToCorrectEndpoint()
     {
-        var reorder = new ReportElementReorder { Ids = [1, 2], Target = 3 };
+        var reorder = new ReportElementReorder { CollectionId = 10, Ids = [1, 2], Target = 3 };
         ConnectionHandler
             .PostAsync<NoContentResponse, ReportElementReorder>(Arg.Any<string>(), Arg.Any<ReportElementReorder>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<NoContentResponse>());
@@ -121,92 +122,90 @@ public class ReportElementServiceTests : ServiceTestBase<ReportElementService>
     [Test]
     public async Task GetData_ShouldCallCorrectEndpoint()
     {
-        var entry = new Entry { Id = 42 };
+        var request = new ReportElementRequest { ElementId = 42 };
         ConnectionHandler
-            .GetAsync<SingleResponse<ReportElement>, Entry>(
-                Arg.Any<string>(), Arg.Any<Entry>(), Arg.Any<CancellationToken>())
-            .Returns(new ApiResult<SingleResponse<ReportElement>>());
+            .GetAsync(Arg.Any<string>(), Arg.Any<ReportElementRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult());
 
-        await Service.GetData(entry);
+        await Service.GetData(request);
 
         await ConnectionHandler.Received(1)
-            .GetAsync<SingleResponse<ReportElement>, Entry>(
-                ReportEndpoints.Element.ReadJson, entry, Arg.Any<CancellationToken>());
+            .GetAsync(ReportEndpoints.Element.ReadJson, request, Arg.Any<CancellationToken>());
     }
 
     [Test]
     public async Task GetDataHtml_ShouldCallGetBinaryAsync()
     {
-        var entry = new Entry { Id = 42 };
+        var request = new ReportElementRequest { ElementId = 42 };
         ConnectionHandler
-            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<Entry>(), Arg.Any<CancellationToken>())
+            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<ReportElementRequest>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<BinaryResponse> { ResponseData = new() { Data = [1, 2, 3] } });
 
-        var result = await Service.GetDataHtml(entry);
+        var result = await Service.GetDataHtml(request);
 
         await ConnectionHandler.Received(1)
-            .GetBinaryAsync(ReportEndpoints.Element.ReadHtml, entry, Arg.Any<CancellationToken>());
+            .GetBinaryAsync(ReportEndpoints.Element.ReadHtml, request, Arg.Any<CancellationToken>());
         result.ShouldNotBeNull();
     }
 
     [Test]
     public async Task GetMeta_ShouldCallCorrectEndpoint()
     {
-        var entry = new Entry { Id = 42 };
+        var request = new ReportElementRequest { ElementId = 42 };
         ConnectionHandler
-            .GetAsync<SingleResponse<ReportElement>, Entry>(
-                Arg.Any<string>(), Arg.Any<Entry>(), Arg.Any<CancellationToken>())
-            .Returns(new ApiResult<SingleResponse<ReportElement>>());
+            .GetAsync<SingleResponse<ReportElementMeta>, ReportElementRequest>(
+                Arg.Any<string>(), Arg.Any<ReportElementRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResponse<ReportElementMeta>>());
 
-        await Service.GetMeta(entry);
+        await Service.GetMeta(request);
 
         await ConnectionHandler.Received(1)
-            .GetAsync<SingleResponse<ReportElement>, Entry>(
-                ReportEndpoints.Element.ReadMeta, entry, Arg.Any<CancellationToken>());
+            .GetAsync<SingleResponse<ReportElementMeta>, ReportElementRequest>(
+                ReportEndpoints.Element.ReadMeta, request, Arg.Any<CancellationToken>());
     }
 
     [Test]
     public async Task DownloadPdf_ShouldCallGetBinaryAsync()
     {
-        var entry = new Entry { Id = 42 };
+        var request = new ReportElementRequest { ElementId = 42 };
         ConnectionHandler
-            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<Entry>(), Arg.Any<CancellationToken>())
+            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<ReportElementRequest>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<BinaryResponse> { ResponseData = new() { Data = [1, 2, 3] } });
 
-        var result = await Service.DownloadPdf(entry);
+        var result = await Service.DownloadPdf(request);
 
         await ConnectionHandler.Received(1)
-            .GetBinaryAsync(ReportEndpoints.Element.DownloadPdf, entry, Arg.Any<CancellationToken>());
+            .GetBinaryAsync(ReportEndpoints.Element.DownloadPdf, request, Arg.Any<CancellationToken>());
         result.ShouldNotBeNull();
     }
 
     [Test]
     public async Task DownloadCsv_ShouldCallGetBinaryAsync()
     {
-        var entry = new Entry { Id = 42 };
+        var request = new ReportElementRequest { ElementId = 42 };
         ConnectionHandler
-            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<Entry>(), Arg.Any<CancellationToken>())
+            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<ReportElementRequest>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<BinaryResponse> { ResponseData = new() { Data = [1, 2, 3] } });
 
-        var result = await Service.DownloadCsv(entry);
+        var result = await Service.DownloadCsv(request);
 
         await ConnectionHandler.Received(1)
-            .GetBinaryAsync(ReportEndpoints.Element.DownloadCsv, entry, Arg.Any<CancellationToken>());
+            .GetBinaryAsync(ReportEndpoints.Element.DownloadCsv, request, Arg.Any<CancellationToken>());
         result.ShouldNotBeNull();
     }
 
     [Test]
     public async Task DownloadExcel_ShouldCallGetBinaryAsync()
     {
-        var entry = new Entry { Id = 42 };
+        var request = new ReportElementRequest { ElementId = 42 };
         ConnectionHandler
-            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<Entry>(), Arg.Any<CancellationToken>())
+            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<ReportElementRequest>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<BinaryResponse> { ResponseData = new() { Data = [1, 2, 3] } });
 
-        var result = await Service.DownloadExcel(entry);
+        var result = await Service.DownloadExcel(request);
 
         await ConnectionHandler.Received(1)
-            .GetBinaryAsync(ReportEndpoints.Element.DownloadXlsx, entry, Arg.Any<CancellationToken>());
+            .GetBinaryAsync(ReportEndpoints.Element.DownloadXlsx, request, Arg.Any<CancellationToken>());
         result.ShouldNotBeNull();
     }
 }

--- a/tests/CashCtrlApiNet.UnitTests/Report/ReportSetServiceTests.cs
+++ b/tests/CashCtrlApiNet.UnitTests/Report/ReportSetServiceTests.cs
@@ -121,76 +121,76 @@ public class ReportSetServiceTests : ServiceTestBase<ReportSetService>
     [Test]
     public async Task GetMeta_ShouldCallCorrectEndpoint()
     {
-        var entry = new Entry { Id = 42 };
+        var request = new ReportCollectionRequest { CollectionId = 42 };
         ConnectionHandler
-            .GetAsync<SingleResponse<ReportSet>, Entry>(
-                Arg.Any<string>(), Arg.Any<Entry>(), Arg.Any<CancellationToken>())
-            .Returns(new ApiResult<SingleResponse<ReportSet>>());
+            .GetAsync<SingleResponse<ReportCollectionMeta>, ReportCollectionRequest>(
+                Arg.Any<string>(), Arg.Any<ReportCollectionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<SingleResponse<ReportCollectionMeta>>());
 
-        await Service.GetMeta(entry);
+        await Service.GetMeta(request);
 
         await ConnectionHandler.Received(1)
-            .GetAsync<SingleResponse<ReportSet>, Entry>(
-                ReportEndpoints.Set.ReadMeta, entry, Arg.Any<CancellationToken>());
+            .GetAsync<SingleResponse<ReportCollectionMeta>, ReportCollectionRequest>(
+                ReportEndpoints.Set.ReadMeta, request, Arg.Any<CancellationToken>());
     }
 
     [Test]
     public async Task DownloadPdf_ShouldCallGetBinaryAsync()
     {
-        var entry = new Entry { Id = 42 };
+        var request = new ReportCollectionRequest { CollectionId = 42 };
         ConnectionHandler
-            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<Entry>(), Arg.Any<CancellationToken>())
+            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<ReportCollectionRequest>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<BinaryResponse> { ResponseData = new() { Data = [1, 2, 3] } });
 
-        var result = await Service.DownloadPdf(entry);
+        var result = await Service.DownloadPdf(request);
 
         await ConnectionHandler.Received(1)
-            .GetBinaryAsync(ReportEndpoints.Set.DownloadPdf, entry, Arg.Any<CancellationToken>());
+            .GetBinaryAsync(ReportEndpoints.Set.DownloadPdf, request, Arg.Any<CancellationToken>());
         result.ShouldNotBeNull();
     }
 
     [Test]
     public async Task DownloadCsv_ShouldCallGetBinaryAsync()
     {
-        var entry = new Entry { Id = 42 };
+        var request = new ReportCollectionRequest { CollectionId = 42 };
         ConnectionHandler
-            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<Entry>(), Arg.Any<CancellationToken>())
+            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<ReportCollectionRequest>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<BinaryResponse> { ResponseData = new() { Data = [1, 2, 3] } });
 
-        var result = await Service.DownloadCsv(entry);
+        var result = await Service.DownloadCsv(request);
 
         await ConnectionHandler.Received(1)
-            .GetBinaryAsync(ReportEndpoints.Set.DownloadCsv, entry, Arg.Any<CancellationToken>());
+            .GetBinaryAsync(ReportEndpoints.Set.DownloadCsv, request, Arg.Any<CancellationToken>());
         result.ShouldNotBeNull();
     }
 
     [Test]
     public async Task DownloadExcel_ShouldCallGetBinaryAsync()
     {
-        var entry = new Entry { Id = 42 };
+        var request = new ReportCollectionRequest { CollectionId = 42 };
         ConnectionHandler
-            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<Entry>(), Arg.Any<CancellationToken>())
+            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<ReportCollectionRequest>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<BinaryResponse> { ResponseData = new() { Data = [1, 2, 3] } });
 
-        var result = await Service.DownloadExcel(entry);
+        var result = await Service.DownloadExcel(request);
 
         await ConnectionHandler.Received(1)
-            .GetBinaryAsync(ReportEndpoints.Set.DownloadXlsx, entry, Arg.Any<CancellationToken>());
+            .GetBinaryAsync(ReportEndpoints.Set.DownloadXlsx, request, Arg.Any<CancellationToken>());
         result.ShouldNotBeNull();
     }
 
     [Test]
     public async Task DownloadAnnualReport_ShouldCallGetBinaryAsync()
     {
-        var entry = new Entry { Id = 42 };
+        var request = new ReportAnnualReportRequest();
         ConnectionHandler
-            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<Entry>(), Arg.Any<CancellationToken>())
+            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<ReportAnnualReportRequest>(), Arg.Any<CancellationToken>())
             .Returns(new ApiResult<BinaryResponse> { ResponseData = new() { Data = [1, 2, 3] } });
 
-        var result = await Service.DownloadAnnualReport(entry);
+        var result = await Service.DownloadAnnualReport(request);
 
         await ConnectionHandler.Received(1)
-            .GetBinaryAsync(ReportEndpoints.Set.DownloadAnnualReport, entry, Arg.Any<CancellationToken>());
+            .GetBinaryAsync(ReportEndpoints.Set.DownloadAnnualReport, request, Arg.Any<CancellationToken>());
         result.ShouldNotBeNull();
     }
 }


### PR DESCRIPTION
## Summary

Group 1 (Report) extended E2E verification uncovered **six live-API discrepancies** in `ReportElement` and `ReportSet` that were rejecting requests or failing deserialization. This PR rewrites the models, service signatures, and tests so the Report domain matches the live API, and documents the discrepancies in `doc/analysis/2026-03-29-api-doc-discrepancies.md` §§28-33.

## Key discrepancies fixed

- **`type` required on `report/element/create.json`** (docs say optional). New `ReportElementType` enum (~40 values).
- **Parent scope is `collectionId`, not `reportId`/`setId`.** Consistent across `/report/collection/*` write/read/download endpoints and the element's `create`/`update`. Child element endpoints use yet a third name (`elementId` / `id`) depending on the operation.
- **Reorder requires undocumented `collectionId`** — same pattern as `customfield/reorder.json`'s undocumented `type` field. Omitting it yields `ID missing.`
- **Meta endpoints return a slim header shape**, not the entity shape. Adds dedicated `ReportElementMeta` and `ReportCollectionMeta` records (title/text/periodLabel + logo for collection); neither payload has an `id` field.
- **`/report/element/data.json` shape varies by report type** (tree for `ChartOfAccounts`, flat list for `Journal`, grouped sections for `Balance`/`Pls`, …). `GetData` now returns untyped `ApiResult` and carries the raw JSON on `RawResponseContent`; callers parse into their report type.
- **`CashCtrlConnectionHandler.GetApiResult` (untyped path) now always populates `RawResponseContent`** — previously it was only set on deserialization failure, which would have hidden the whole point of the untyped `GetData`.

## Test edge cases

- `Update_Success` drops the round-trip verify of `negateAmount` — `ChartOfAccounts` silently discards it on read (only meaningful for element types with a primary amount dimension).
- `GetDataHtml_Success` no longer asserts `FileName`; the HTML endpoint serves inline with no `Content-Disposition` header, unlike PDF/CSV/Excel.

## Test plan

- [x] `dotnet build CashCtrlApiNet.sln` — 0 warnings / 0 errors
- [x] Unit tests: 631/631 green
- [x] Integration tests: 460/460 green (single-threaded; parallel occasionally flakes on unrelated `Salary*` WireMock port races — pre-existing, tracked separately)
- [x] E2E `Category=E2e&FullyQualifiedName~Report`: 22/22 green against live API

Docs updated: `doc/analysis/2026-03-29-api-doc-discrepancies.md` (+§§28-33) and `doc/analysis/2026-03-29-e2e-test-verification.md` (Report element/set sub-group marked verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)